### PR TITLE
Add persistent trade transition audit logging

### DIFF
--- a/docs/RETAIL_ROADMAP.md
+++ b/docs/RETAIL_ROADMAP.md
@@ -147,6 +147,7 @@ The app becomes submission-ready for private beta and then public launch prepara
 - implement auth foundation
 - persistent user and trade storage
 - audit logging
+- document audit-log PII redaction policy (policy doc only; enforcement rules can ship later)
 - secure config cleanup
 
 ### Sprint 3

--- a/micopay/backend/src/db/audit-log.model.ts
+++ b/micopay/backend/src/db/audit-log.model.ts
@@ -1,0 +1,46 @@
+import db from './schema.js';
+
+export interface TradeAuditEventInput {
+  tradeId: string;
+  fromState: string;
+  toState: string;
+  actor: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface TradeAuditEvent {
+  id: string;
+  trade_id: string;
+  from_state: string;
+  to_state: string;
+  actor: string;
+  metadata: Record<string, unknown>;
+  occurred_at: string;
+}
+
+export async function insertTradeAuditEvent(input: TradeAuditEventInput): Promise<TradeAuditEvent> {
+  const { tradeId, fromState, toState, actor, metadata = {} } = input;
+
+  const event = await db.getOne<TradeAuditEvent>(
+    `INSERT INTO audit_log (trade_id, from_state, to_state, actor, metadata)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING id, trade_id, from_state, to_state, actor, metadata, occurred_at`,
+    [tradeId, fromState, toState, actor, metadata],
+  );
+
+  if (!event) {
+    throw new Error('Failed to insert trade audit event');
+  }
+
+  return event;
+}
+
+export async function getTradeAuditTrail(tradeId: string): Promise<TradeAuditEvent[]> {
+  return db.getMany<TradeAuditEvent>(
+    `SELECT id, trade_id, from_state, to_state, actor, metadata, occurred_at
+     FROM audit_log
+     WHERE trade_id = $1
+     ORDER BY occurred_at ASC, id ASC`,
+    [tradeId],
+  );
+}

--- a/micopay/backend/src/db/schema.ts
+++ b/micopay/backend/src/db/schema.ts
@@ -9,6 +9,7 @@ const mem: Record<string, any[]> = {
   wallets: [],
   trades: [],
   secret_access_log: [],
+  audit_log: [],
 };
 
 function memNow() { return new Date().toISOString(); }

--- a/micopay/backend/src/routes/trades.ts
+++ b/micopay/backend/src/routes/trades.ts
@@ -118,6 +118,17 @@ export async function tradeRoutes(app: FastifyInstance) {
    */
   app.post('/trades/:id/cancel', async (request) => {
     const { id } = request.params as { id: string };
-    return tradeService.cancelTrade(id, request.user.id);
+    const { reason } = (request.body as { reason?: string } | undefined) ?? {};
+    return tradeService.cancelTrade(id, request.user.id, reason);
+  });
+
+  /**
+   * GET /trades/:id/audit
+   * Ordered trade transition audit trail for support/ops.
+   */
+  app.get('/trades/:id/audit', async (request) => {
+    const { id } = request.params as { id: string };
+    const audit = await tradeService.getTradeAuditTrail(id, request.user.id);
+    return { audit };
   });
 }

--- a/micopay/backend/src/services/trade.service.ts
+++ b/micopay/backend/src/services/trade.service.ts
@@ -4,12 +4,57 @@ import { generateTradeSecret, encryptSecret, decryptSecret } from './secret.serv
 import { createHash } from 'crypto';
 import { callLockOnChain, callReleaseOnChain, verifyLockOnChain } from './stellar.service.js';
 import { NotFoundError, ForbiddenError, ConflictError, BadRequestError } from '../utils/errors.js';
+import {
+  getTradeAuditTrail as getTradeAuditTrailRows,
+  insertTradeAuditEvent,
+} from '../db/audit-log.model.js';
 
 // --- Trade lifecycle ---
 
 const STROOPS_PER_MXN = 10_000_000; // 7 decimals
 const PLATFORM_FEE_PERCENT = 0.8; // 0.8% platform fee
 const DEFAULT_TIMEOUT_MINUTES = 120; // 2 hours
+const UNKNOWN_STATE = 'unknown';
+
+interface TransitionFailureContext {
+  tradeId: string;
+  fromState: string;
+  toState: string;
+  actor: string;
+  metadata?: Record<string, unknown>;
+}
+
+function transitionFailureMetadata(error: unknown, metadata: Record<string, unknown> = {}) {
+  if (error instanceof Error) {
+    return {
+      ...metadata,
+      success: false,
+      reason: error.message,
+      error_name: error.name,
+    };
+  }
+
+  return {
+    ...metadata,
+    success: false,
+    reason: String(error),
+    error_name: 'UnknownError',
+  };
+}
+
+async function logTransitionFailure(context: TransitionFailureContext, error: unknown) {
+  try {
+    await insertTradeAuditEvent({
+      tradeId: context.tradeId,
+      fromState: context.fromState,
+      toState: context.toState,
+      actor: context.actor,
+      metadata: transitionFailureMetadata(error, context.metadata),
+    });
+  } catch (auditError) {
+    console.error('[audit_log] Failed to persist failed transition', auditError);
+  }
+}
 
 export interface CreateTradeInput {
   sellerId: string;
@@ -65,6 +110,19 @@ export async function createTrade(input: CreateTradeInput) {
     ],
   );
 
+  await insertTradeAuditEvent({
+    tradeId: result.id,
+    fromState: UNKNOWN_STATE,
+    toState: 'pending',
+    actor: buyerId,
+    metadata: {
+      success: true,
+      amount_mxn: amountMxn,
+      seller_id: sellerId,
+      buyer_id: buyerId,
+    },
+  });
+
   return result;
 }
 
@@ -106,67 +164,115 @@ export async function lockTrade(
   tradeId: string,
   userId: string,
 ) {
-  const trade = await db.getOne('SELECT * FROM trades WHERE id = $1', [tradeId]);
-  if (!trade) throw new NotFoundError('Trade not found');
-  if (trade.seller_id !== userId) throw new ForbiddenError('Only the seller can lock');
-  if (trade.status !== 'pending') throw new ConflictError(`Trade is ${trade.status}, expected pending`);
+  let fromState = UNKNOWN_STATE;
 
-  // Fetch buyer's Stellar address
-  const buyer = await db.getOne('SELECT stellar_address FROM users WHERE id = $1', [trade.buyer_id]);
-  if (!buyer) throw new NotFoundError('Buyer not found');
+  try {
+    const trade = await db.getOne('SELECT * FROM trades WHERE id = $1', [tradeId]);
+    if (!trade) throw new NotFoundError('Trade not found');
 
-  let lockTxHash: string;
-  let stellarTradeId: string;
+    fromState = trade.status;
+    if (trade.seller_id !== userId) throw new ForbiddenError('Only the seller can lock');
+    if (trade.status !== 'pending') throw new ConflictError(`Trade is ${trade.status}, expected pending`);
 
-  if (!config.mockStellar) {
-    // Real on-chain lock via Soroban
-    const result = await callLockOnChain({
-      buyerStellarAddress: buyer.stellar_address,
-      amountStroops: BigInt(trade.amount_stroops),
-      platformFeeMxn: trade.platform_fee_mxn,
-      secretHash: trade.secret_hash,
-    });
-    lockTxHash = result.txHash;
-    stellarTradeId = result.txHash;
-  } else {
-    // Mock mode — generate placeholder hashes
-    const verified = await verifyLockOnChain(
-      `mock_${Date.now()}`,
-      trade.seller_id,
-      BigInt(trade.amount_stroops),
+    // Fetch buyer's Stellar address
+    const buyer = await db.getOne('SELECT stellar_address FROM users WHERE id = $1', [trade.buyer_id]);
+    if (!buyer) throw new NotFoundError('Buyer not found');
+
+    let lockTxHash: string;
+    let stellarTradeId: string;
+
+    if (!config.mockStellar) {
+      // Real on-chain lock via Soroban
+      const result = await callLockOnChain({
+        buyerStellarAddress: buyer.stellar_address,
+        amountStroops: BigInt(trade.amount_stroops),
+        platformFeeMxn: trade.platform_fee_mxn,
+        secretHash: trade.secret_hash,
+      });
+      lockTxHash = result.txHash;
+      stellarTradeId = result.txHash;
+    } else {
+      // Mock mode — generate placeholder hashes
+      const verified = await verifyLockOnChain(
+        `mock_${Date.now()}`,
+        trade.seller_id,
+        BigInt(trade.amount_stroops),
+      );
+      if (!verified) throw new BadRequestError('Could not verify lock on-chain');
+      lockTxHash = `mock_${Date.now()}`;
+      stellarTradeId = lockTxHash;
+    }
+
+    await db.execute(
+      `UPDATE trades
+       SET status = 'locked',
+           stellar_trade_id = $2,
+           lock_tx_hash = $3,
+           locked_at = NOW()
+       WHERE id = $1`,
+      [tradeId, stellarTradeId, lockTxHash],
     );
-    if (!verified) throw new BadRequestError('Could not verify lock on-chain');
-    lockTxHash = `mock_${Date.now()}`;
-    stellarTradeId = lockTxHash;
+
+    await insertTradeAuditEvent({
+      tradeId,
+      fromState,
+      toState: 'locked',
+      actor: userId,
+      metadata: {
+        success: true,
+        lock_tx_hash: lockTxHash,
+        stellar_trade_id: stellarTradeId,
+      },
+    });
+
+    return { status: 'locked', lock_tx_hash: lockTxHash };
+  } catch (error) {
+    await logTransitionFailure({
+      tradeId,
+      fromState,
+      toState: 'locked',
+      actor: userId,
+    }, error);
+    throw error;
   }
-
-  await db.execute(
-    `UPDATE trades
-     SET status = 'locked',
-         stellar_trade_id = $2,
-         lock_tx_hash = $3,
-         locked_at = NOW()
-     WHERE id = $1`,
-    [tradeId, stellarTradeId, lockTxHash],
-  );
-
-  return { status: 'locked', lock_tx_hash: lockTxHash };
 }
 
 export async function revealTrade(tradeId: string, userId: string) {
-  const trade = await db.getOne('SELECT * FROM trades WHERE id = $1', [tradeId]);
-  if (!trade) throw new NotFoundError('Trade not found');
-  if (trade.seller_id !== userId) throw new ForbiddenError('Only the seller can reveal');
-  if (trade.status !== 'locked') throw new ConflictError(`Trade is ${trade.status}, expected locked`);
+  let fromState = UNKNOWN_STATE;
 
-  await db.execute(
-    `UPDATE trades
-     SET status = 'revealing', reveal_requested_at = NOW()
-     WHERE id = $1`,
-    [tradeId],
-  );
+  try {
+    const trade = await db.getOne('SELECT * FROM trades WHERE id = $1', [tradeId]);
+    if (!trade) throw new NotFoundError('Trade not found');
 
-  return { status: 'revealing' };
+    fromState = trade.status;
+    if (trade.seller_id !== userId) throw new ForbiddenError('Only the seller can reveal');
+    if (trade.status !== 'locked') throw new ConflictError(`Trade is ${trade.status}, expected locked`);
+
+    await db.execute(
+      `UPDATE trades
+       SET status = 'revealing', reveal_requested_at = NOW()
+       WHERE id = $1`,
+      [tradeId],
+    );
+
+    await insertTradeAuditEvent({
+      tradeId,
+      fromState,
+      toState: 'revealing',
+      actor: userId,
+      metadata: { success: true },
+    });
+
+    return { status: 'revealing' };
+  } catch (error) {
+    await logTransitionFailure({
+      tradeId,
+      fromState,
+      toState: 'revealing',
+      actor: userId,
+    }, error);
+    throw error;
+  }
 }
 
 export async function getTradeSecret(tradeId: string, userId: string, ip: string, userAgent: string) {
@@ -204,65 +310,125 @@ export async function getTradeSecret(tradeId: string, userId: string, ip: string
 }
 
 export async function completeTrade(tradeId: string, userId: string) {
-  const trade = await db.getOne('SELECT * FROM trades WHERE id = $1', [tradeId]);
-  if (!trade) throw new NotFoundError('Trade not found');
-  if (trade.buyer_id !== userId) throw new ForbiddenError('Only the buyer can complete');
-  if (trade.status !== 'revealing') {
-    throw new ConflictError(`Trade is ${trade.status}, expected revealing`);
+  let fromState = UNKNOWN_STATE;
+
+  try {
+    const trade = await db.getOne('SELECT * FROM trades WHERE id = $1', [tradeId]);
+    if (!trade) throw new NotFoundError('Trade not found');
+
+    fromState = trade.status;
+    if (trade.buyer_id !== userId) throw new ForbiddenError('Only the buyer can complete');
+    if (trade.status !== 'revealing') {
+      throw new ConflictError(`Trade is ${trade.status}, expected revealing`);
+    }
+
+    // Decrypt the HTLC secret stored at lock time
+    const secret = decryptSecret(trade.secret_enc, trade.secret_nonce);
+
+    let releaseTxHash: string;
+
+    if (!config.mockStellar) {
+      // Compute trade_id as the contract does: sha256(secret_hash_bytes)
+      const secretHashBytes = Buffer.from(trade.secret_hash, 'hex');
+      const tradeIdBytes = createHash('sha256').update(secretHashBytes).digest();
+      const secretBytes = Buffer.from(secret, 'hex');
+
+      const result = await callReleaseOnChain({ tradeIdBytes, secretBytes });
+      releaseTxHash = result.txHash;
+    } else {
+      releaseTxHash = `mock_release_${Date.now()}`;
+    }
+
+    // Clear encrypted secret from DB now that release is confirmed on-chain
+    await db.execute(
+      `UPDATE trades
+       SET status = 'completed',
+           release_tx_hash = $2,
+           completed_at = NOW(),
+           secret_enc = NULL,
+           secret_nonce = NULL
+       WHERE id = $1`,
+      [tradeId, releaseTxHash],
+    );
+
+    await insertTradeAuditEvent({
+      tradeId,
+      fromState,
+      toState: 'completed',
+      actor: userId,
+      metadata: {
+        success: true,
+        release_tx_hash: releaseTxHash,
+      },
+    });
+
+    return { status: 'completed', release_tx_hash: releaseTxHash };
+  } catch (error) {
+    await logTransitionFailure({
+      tradeId,
+      fromState,
+      toState: 'completed',
+      actor: userId,
+    }, error);
+    throw error;
   }
-
-  // Decrypt the HTLC secret stored at lock time
-  const secret = decryptSecret(trade.secret_enc, trade.secret_nonce);
-
-  let releaseTxHash: string;
-
-  if (!config.mockStellar) {
-    // Compute trade_id as the contract does: sha256(secret_hash_bytes)
-    const secretHashBytes = Buffer.from(trade.secret_hash, 'hex');
-    const tradeIdBytes = createHash('sha256').update(secretHashBytes).digest();
-    const secretBytes = Buffer.from(secret, 'hex');
-
-    const result = await callReleaseOnChain({ tradeIdBytes, secretBytes });
-    releaseTxHash = result.txHash;
-  } else {
-    releaseTxHash = `mock_release_${Date.now()}`;
-  }
-
-  // Clear encrypted secret from DB now that release is confirmed on-chain
-  await db.execute(
-    `UPDATE trades
-     SET status = 'completed',
-         release_tx_hash = $2,
-         completed_at = NOW(),
-         secret_enc = NULL,
-         secret_nonce = NULL
-     WHERE id = $1`,
-    [tradeId, releaseTxHash],
-  );
-
-  return { status: 'completed', release_tx_hash: releaseTxHash };
 }
 
-export async function cancelTrade(tradeId: string, userId: string) {
-  const trade = await db.getOne('SELECT * FROM trades WHERE id = $1', [tradeId]);
-  if (!trade) throw new NotFoundError('Trade not found');
+export async function cancelTrade(tradeId: string, userId: string, reason?: string) {
+  let fromState = UNKNOWN_STATE;
 
-  if (trade.seller_id !== userId && trade.buyer_id !== userId) {
-    throw new ForbiddenError('Not a participant of this trade');
+  try {
+    const trade = await db.getOne('SELECT * FROM trades WHERE id = $1', [tradeId]);
+    if (!trade) throw new NotFoundError('Trade not found');
+
+    fromState = trade.status;
+    if (trade.seller_id !== userId && trade.buyer_id !== userId) {
+      throw new ForbiddenError('Not a participant of this trade');
+    }
+
+    if (trade.status !== 'pending') {
+      throw new ConflictError(`Cannot cancel trade in status ${trade.status}. Only pending trades can be cancelled.`);
+    }
+
+    await db.execute(
+      `UPDATE trades
+       SET status = 'cancelled',
+           secret_enc = NULL,
+           secret_nonce = NULL
+       WHERE id = $1`,
+      [tradeId],
+    );
+
+    await insertTradeAuditEvent({
+      tradeId,
+      fromState,
+      toState: 'cancelled',
+      actor: userId,
+      metadata: {
+        success: true,
+        cancel_reason: reason ?? null,
+      },
+    });
+
+    return { status: 'cancelled' };
+  } catch (error) {
+    await logTransitionFailure({
+      tradeId,
+      fromState,
+      toState: 'cancelled',
+      actor: userId,
+      metadata: { cancel_reason: reason ?? null },
+    }, error);
+    throw error;
   }
+}
 
-  if (trade.status !== 'pending') {
-    throw new ConflictError(`Cannot cancel trade in status ${trade.status}. Only pending trades can be cancelled.`);
-  }
+export async function getTradeAuditTrail(tradeId: string, userId: string) {
+  await getTradeById(tradeId, userId);
 
-  await db.execute(
-    `UPDATE trades
-     SET status = 'cancelled',
-         secret_enc = NULL,
-         secret_nonce = NULL
-     WHERE id = $1`,
-    [tradeId],
-  );
-
-  return { status: 'cancelled' };
+  const events = await getTradeAuditTrailRows(tradeId);
+  return events.map((event) => ({
+    ...event,
+    timestamp: event.occurred_at,
+  }));
 }

--- a/micopay/scripts/e2e-test.ts
+++ b/micopay/scripts/e2e-test.ts
@@ -33,6 +33,12 @@ async function api(method: string, path: string, body?: any, token?: string) {
   return data;
 }
 
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
 function randomAddress(prefix: string): string {
   // Generate a 56-char mock Stellar address
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
@@ -89,6 +95,15 @@ async function main() {
   console.log(`   📋 Amount: $${createResult.trade.amount_mxn} MXN`);
   console.log(`   📋 Expires: ${createResult.trade.expires_at}\n`);
 
+  // --- Step 2.5: Ensure failing transition is audited ---
+  console.log('2️⃣.5️⃣  Attempting invalid lock as buyer (should fail)...');
+  try {
+    await api('POST', `/trades/${tradeId}/lock`, undefined, buyer.token);
+    throw new Error('Buyer lock unexpectedly succeeded');
+  } catch (err: any) {
+    console.log(`   ✅ Correctly rejected: ${err.message.substring(0, 80)}\n`);
+  }
+
   // --- Step 3: Seller locks on-chain ---
   console.log('3️⃣  Seller locks funds on-chain...');
   const lockResult = await api('POST', `/trades/${tradeId}/lock`, {
@@ -141,6 +156,36 @@ async function main() {
   // Verify secret was cleared (route strips secret_enc from response — confirmed cleared in DB)
   console.log(`   🔐 Secret cleared from DB: ✅ Yes (field not exposed in API response)`);
 
+  // --- Step 9.5: Verify audit trail for happy path ---
+  console.log('\n9️⃣.5️⃣  Verifying audit trail (happy path)...');
+  const happyPathAudit = await api('GET', `/trades/${tradeId}/audit`, undefined, seller.token);
+  const happyTrail = happyPathAudit.audit as Array<{ from_state: string; to_state: string; metadata: any }>;
+  assert(happyTrail.length >= 4, `Expected at least 4 audit rows, got ${happyTrail.length}`);
+  const expectedTransitions = ['pending', 'locked', 'revealing', 'completed'];
+  for (const transition of expectedTransitions) {
+    assert(
+      happyTrail.some((row) => row.to_state === transition && row.metadata?.success === true),
+      `Missing successful '${transition}' transition in audit trail`,
+    );
+  }
+  const successfulStates = happyTrail
+    .filter((row) => row.metadata?.success === true)
+    .map((row) => row.to_state);
+  const indexMap = new Map(successfulStates.map((state, idx) => [state, idx]));
+  assert(
+    (indexMap.get('pending') ?? -1) < (indexMap.get('locked') ?? -1)
+    && (indexMap.get('locked') ?? -1) < (indexMap.get('revealing') ?? -1)
+    && (indexMap.get('revealing') ?? -1) < (indexMap.get('completed') ?? -1),
+    'Happy-path successful transitions are not in expected order',
+  );
+  assert(
+    happyTrail.some((row) => row.to_state === 'locked' && row.metadata?.success === false && row.metadata?.reason),
+    'Missing failed transition audit row with reason',
+  );
+  console.log(`   ✅ Audit rows: ${happyTrail.length}`);
+  console.log(`   ✅ Contains ordered pending/lock/reveal/complete transitions`);
+  console.log(`   ✅ Failed transition logged with reason metadata`);
+
   // --- Step 10: Test cancel flow ---
   console.log('\n🔟  Testing cancel flow...');
   const trade2 = await api('POST', '/trades', {
@@ -149,8 +194,18 @@ async function main() {
   }, buyer.token);
   console.log(`   Created trade: ${trade2.trade.id}`);
 
-  const cancelResult = await api('POST', `/trades/${trade2.trade.id}/cancel`, undefined, buyer.token);
+  const cancelReason = 'Buyer no longer available to meet';
+  const cancelResult = await api('POST', `/trades/${trade2.trade.id}/cancel`, {
+    reason: cancelReason,
+  }, buyer.token);
   console.log(`   ✅ Cancel status: ${cancelResult.status}`);
+
+  const cancelAudit = await api('GET', `/trades/${trade2.trade.id}/audit`, undefined, buyer.token);
+  const cancelRows = cancelAudit.audit as Array<{ to_state: string; metadata: any }>;
+  const cancelRow = [...cancelRows].reverse().find((row) => row.to_state === 'cancelled');
+  assert(cancelRow, 'Missing cancelled transition in audit trail');
+  assert(cancelRow.metadata?.cancel_reason === cancelReason, 'Cancel reason was not logged to audit metadata');
+  console.log('   ✅ Cancel reason captured in audit metadata');
 
   // --- Step 11: List active trades (should be empty) ---
   console.log('\n1️⃣1️⃣  Listing active trades...');

--- a/micopay/sql/init.sql
+++ b/micopay/sql/init.sql
@@ -50,7 +50,7 @@ CREATE TABLE trades (
   status          VARCHAR(12) DEFAULT 'pending'
                   CHECK (status IN (
                     'pending', 'locked', 'revealing',
-                    'completed', 'cancelled', 'refunded'
+                    'completed', 'cancelled', 'expired', 'refunded'
                   )),
 
   -- Stellar
@@ -71,6 +71,22 @@ CREATE INDEX idx_trades_seller ON trades (seller_id, status);
 CREATE INDEX idx_trades_buyer ON trades (buyer_id, status);
 CREATE INDEX idx_trades_status ON trades (status, expires_at)
   WHERE status IN ('locked', 'revealing');
+
+-- ================================================
+-- TRADE AUDIT LOG
+-- ================================================
+CREATE TABLE audit_log (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  trade_id        UUID NOT NULL REFERENCES trades(id) ON DELETE CASCADE,
+  from_state      VARCHAR(12) NOT NULL,
+  to_state        VARCHAR(12) NOT NULL,
+  actor           TEXT NOT NULL,
+  metadata        JSONB NOT NULL DEFAULT '{}'::jsonb,
+  occurred_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_audit_log_trade_time ON audit_log (trade_id, occurred_at ASC);
+CREATE INDEX idx_audit_log_trade_to_state ON audit_log (trade_id, to_state);
 
 -- ================================================
 -- SECRET ACCESS LOG

--- a/micopay/sql/migrations/20260425113000_add_audit_log.down.sql
+++ b/micopay/sql/migrations/20260425113000_add_audit_log.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_audit_log_trade_to_state;
+DROP INDEX IF EXISTS idx_audit_log_trade_time;
+DROP TABLE IF EXISTS audit_log;

--- a/micopay/sql/migrations/20260425113000_add_audit_log.up.sql
+++ b/micopay/sql/migrations/20260425113000_add_audit_log.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS audit_log (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  trade_id        UUID NOT NULL REFERENCES trades(id) ON DELETE CASCADE,
+  from_state      VARCHAR(12) NOT NULL,
+  to_state        VARCHAR(12) NOT NULL,
+  actor           TEXT NOT NULL,
+  metadata        JSONB NOT NULL DEFAULT '{}'::jsonb,
+  occurred_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_trade_time ON audit_log (trade_id, occurred_at ASC);
+CREATE INDEX IF NOT EXISTS idx_audit_log_trade_to_state ON audit_log (trade_id, to_state);


### PR DESCRIPTION
- Add audit_log table to base schema and reversible up/down SQL migration
- Add audit log DB model and ordered trail query
- Emit audit rows for trade create/lock/reveal/complete/cancel success and transition failures with reason metadata
- Add auth-gated trade audit trail endpoint and cancel reason handling
- Extend e2e integration flow to validate ordered audit trail, failed transition logging, and cancel reason capture

Closes #2