### PR TITLE
Persist auth challenges to the database

### DIFF
--- a/apps/api/src/db/auth.ts
+++ b/apps/api/src/db/auth.ts
@@ -1,0 +1,89 @@
+import { query, getOne, execute } from './schema.js';
+
+export interface AuthChallengeRow {
+  id: number;
+  stellar_address: string;
+  challenge: string;
+  expires_at: Date;
+  used_at: Date | null;
+  created_at: Date;
+}
+
+export async function initAuthChallengesTable(): Promise<void> {
+  await query(`
+    CREATE TABLE IF NOT EXISTS auth_challenges (
+      id              SERIAL PRIMARY KEY,
+      stellar_address VARCHAR(56) NOT NULL,
+      challenge       VARCHAR(128) NOT NULL UNIQUE,
+      expires_at      TIMESTAMPTZ NOT NULL,
+      used_at         TIMESTAMPTZ,
+      created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_auth_challenges_address_expires
+      ON auth_challenges(stellar_address, expires_at);
+  `);
+}
+
+/**
+ * Persist a new challenge. Replaces any existing unused, unexpired challenge
+ * for the same address so a client can re-request without accumulating rows.
+ */
+export async function upsertChallenge(
+  stellarAddress: string,
+  challenge: string,
+  expiresAt: Date,
+): Promise<void> {
+  await execute(
+    `INSERT INTO auth_challenges (stellar_address, challenge, expires_at)
+     VALUES ($1, $2, $3)`,
+    [stellarAddress, challenge, expiresAt.toISOString()],
+  );
+}
+
+/**
+ * Look up a challenge row that:
+ *  - matches both address and challenge string
+ *  - has not expired
+ *  - has not been used yet
+ */
+export async function getPendingChallenge(
+  stellarAddress: string,
+  challenge: string,
+): Promise<AuthChallengeRow | null> {
+  return getOne<AuthChallengeRow>(
+    `SELECT * FROM auth_challenges
+     WHERE stellar_address = $1
+       AND challenge       = $2
+       AND expires_at      > NOW()
+       AND used_at         IS NULL`,
+    [stellarAddress, challenge],
+  );
+}
+
+/**
+ * Mark a challenge as consumed. Returns false if the row was already used
+ * (concurrent replay attempt) by relying on the conditional UPDATE.
+ */
+export async function consumeChallenge(id: number): Promise<boolean> {
+  const result = await execute(
+    `UPDATE auth_challenges
+     SET used_at = NOW()
+     WHERE id = $1 AND used_at IS NULL`,
+    [id],
+  );
+  return (result.rowCount ?? 0) > 0;
+}
+
+/**
+ * Delete rows that are either expired or already used and older than 1 hour.
+ * Safe to call on every write; cheap because of the composite index.
+ */
+export async function cleanupExpiredChallenges(): Promise<number> {
+  const result = await execute(
+    `DELETE FROM auth_challenges
+     WHERE expires_at < NOW()
+        OR (used_at IS NOT NULL AND used_at < NOW() - INTERVAL '1 hour')`,
+  );
+  return result.rowCount ?? 0;
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,12 +3,14 @@ import Fastify from "fastify";
 import fastifyCors from "@fastify/cors";
 import { registerRateLimit } from "./plugins/rate-limit.js";
 import { healthRoutes } from "./routes/health.js";
+import { authRoutes } from "./routes/auth.js";
 import { cashRoutes } from "./routes/cash.js";
 import { reputationRoutes } from "./routes/reputation.js";
 import { fundRoutes } from "./routes/fund.js";
 import { serviceRoutes } from "./routes/services.js";
 import { demoRoutes } from "./routes/demo.js";
 import { cetesRoutes } from "./routes/cetes.js";
+import { initAuthChallengesTable } from "./db/auth.js";
 
 const PORT = parseInt(process.env.PORT ?? "3000", 10);
 const NODE_ENV = process.env.NODE_ENV ?? "development";
@@ -23,6 +25,7 @@ app.register(fastifyCors, { origin: "*" });
 registerRateLimit(app);
 
 app.register(healthRoutes);
+app.register(authRoutes);
 app.register(cashRoutes);
 app.register(reputationRoutes);
 app.register(fundRoutes);
@@ -31,6 +34,7 @@ app.register(demoRoutes);
 app.register(cetesRoutes);
 
 async function start() {
+  await initAuthChallengesTable();
   await app.listen({ port: PORT, host: "0.0.0.0" });
   console.log(`MicoPay API running on http://localhost:${PORT}`);
 }

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -2,14 +2,18 @@ import type { FastifyInstance } from 'fastify';
 import { randomBytes } from 'crypto';
 import db from '../db/schema.js';
 import { config } from '../config.js';
-
-// In-memory challenge store (for MVP; use Redis in production)
-const challenges = new Map<string, { challenge: string; expiresAt: number }>();
+import {
+  upsertChallenge,
+  getPendingChallenge,
+  consumeChallenge,
+  cleanupExpiredChallenges,
+} from '../db/auth.js';
 
 export async function authRoutes(app: FastifyInstance & { jwt: any }) {
   /**
    * POST /auth/challenge
    * Generate a challenge for a Stellar address to sign (simplified SEP-10).
+   * Persisted to DB so it survives restarts and works across multiple instances.
    */
   app.post('/auth/challenge', {
     schema: {
@@ -26,11 +30,14 @@ export async function authRoutes(app: FastifyInstance & { jwt: any }) {
     const { stellar_address } = request.body as { stellar_address: string };
 
     const challenge = `micopay-auth-${randomBytes(16).toString('hex')}-${Date.now()}`;
-    const expiresAt = Date.now() + 5 * 60 * 1000; // 5 minutes
+    const expiresAt = new Date(Date.now() + 5 * 60 * 1000); // 5 minutes
 
-    challenges.set(stellar_address, { challenge, expiresAt });
+    // Opportunistic cleanup — keeps the table lean without a separate cron job
+    cleanupExpiredChallenges().catch(() => {});
 
-    return { challenge, expires_at: new Date(expiresAt).toISOString() };
+    await upsertChallenge(stellar_address, challenge, expiresAt);
+
+    return { challenge, expires_at: expiresAt.toISOString() };
   });
 
   /**
@@ -60,14 +67,16 @@ export async function authRoutes(app: FastifyInstance & { jwt: any }) {
       signature: string;
     };
 
-    // Verify challenge exists and hasn't expired
-    const stored = challenges.get(stellar_address);
-    if (!stored || stored.challenge !== challenge) {
+    // Verify challenge exists, belongs to this address, and hasn't expired or been used
+    const stored = await getPendingChallenge(stellar_address, challenge);
+    if (!stored) {
       return reply.status(401).send({ error: 'Invalid or expired challenge' });
     }
-    if (Date.now() > stored.expiresAt) {
-      challenges.delete(stellar_address);
-      return reply.status(401).send({ error: 'Challenge expired' });
+
+    // Atomically mark as used — guards against concurrent replay attempts
+    const consumed = await consumeChallenge(stored.id);
+    if (!consumed) {
+      return reply.status(401).send({ error: 'Challenge already used' });
     }
 
     // In MVP: skip real signature verification
@@ -88,11 +97,8 @@ export async function authRoutes(app: FastifyInstance & { jwt: any }) {
       }
     }
 
-    // Clean up challenge
-    challenges.delete(stellar_address);
-
     // Find or create user
-    let user = await db.getOne(
+    const user = await db.getOne(
       'SELECT id, stellar_address, username FROM users WHERE stellar_address = $1',
       [stellar_address],
     );


### PR DESCRIPTION
Closes #26 

Problem
auth.ts:7 stores SEP-10-style challenges in an in-memory Map. The code itself notes this is MVP-only. A process restart drops every pending challenge; a horizontally scaled deployment serves challenges from the wrong node.

Why it matters
This is the first thing that will break under any real load or multi-instance deploy. Persisting it now keeps the auth contract stable for everything downstream.

