### PR TITLE
Feature/android release hardening

### DIFF
--- a/micopay/frontend/android/.gitignore
+++ b/micopay/frontend/android/.gitignore
@@ -99,3 +99,9 @@ app/src/main/assets/public
 app/src/main/assets/capacitor.config.json
 app/src/main/assets/capacitor.plugins.json
 app/src/main/res/xml/config.xml
+
+
+# Android signing — never commit
+android/keystore.properties
+*.keystore
+*.jks

--- a/micopay/frontend/android/app/build.gradle
+++ b/micopay/frontend/android/app/build.gradle
@@ -8,11 +8,9 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.0"
+        versionName "1.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
-             // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.
-             // Default: https://android.googlesource.com/platform/frameworks/base/+/282e181b58cf72b6ca770dc7ca5f91f135444502/tools/aapt/AaptAssets.cpp#61
             ignoreAssetsPattern = '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
         }
     }
@@ -22,8 +20,6 @@ android {
             if (propsFile.exists()) {
                 def props = new Properties()
                 props.load(new FileInputStream(propsFile))
-                // storeFile path in keystore.properties is resolved relative to
-                // the android/ project root, not android/app/.
                 storeFile rootProject.file(props['storeFile'])
                 storePassword props['storePassword']
                 keyAlias props['keyAlias']
@@ -33,12 +29,17 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            minifyEnabled true
+            shrinkResources true
+            debuggable false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             def propsFile = rootProject.file('keystore.properties')
             if (propsFile.exists()) {
                 signingConfig signingConfigs.release
             }
+        }
+        debug {
+            applicationIdSuffix ".debug"
         }
     }
 }

--- a/micopay/frontend/android/app/proguard-rules.pro
+++ b/micopay/frontend/android/app/proguard-rules.pro
@@ -1,21 +1,48 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# ── Capacitor core ──────────────────────────────────────────────────────────
+-keep class com.getcapacitor.** { *; }
+-keepclassmembers class com.getcapacitor.** { *; }
+-keep @com.getcapacitor.annotation.CapacitorPlugin class * { *; }
+-keep @com.getcapacitor.annotation.Permission class * { *; }
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# ── Capacitor plugins used by MicoPay ────────────────────────────────────────
+# Secure Storage (@aparajita/capacitor-secure-storage)
+-keep class com.aparajita.capacitor.securestorage.** { *; }
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# Barcode Scanning (@capacitor-mlkit/barcode-scanning)
+-keep class io.capawesome.capacitorjs.plugins.mlkit.barcodescanning.** { *; }
+# MLKit barcode — keep model classes
+-keep class com.google.mlkit.** { *; }
+-keep class com.google.android.gms.internal.mlkit_vision_barcode.** { *; }
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# Geolocation (@capacitor/geolocation)
+-keep class com.getcapacitor.plugin.geolocation.** { *; }
+
+# Status Bar (@capacitor/status-bar)
+-keep class com.getcapacitor.plugin.statusbar.** { *; }
+
+# App plugin (@capacitor/app)
+-keep class com.getcapacitor.plugin.app.** { *; }
+
+# ── WebView / JS bridge ───────────────────────────────────────────────────────
+-keepclassmembers class * {
+    @android.webkit.JavascriptInterface <methods>;
+}
+
+# ── AndroidX / support ───────────────────────────────────────────────────────
+-keep class androidx.core.app.CoreComponentFactory { *; }
+
+# ── Reflection & serialization safety ────────────────────────────────────────
+-keepattributes *Annotation*
+-keepattributes Signature
+-keepattributes Exceptions
+-keepattributes EnclosingMethod
+-keepattributes InnerClasses
+
+# ── Stack traces (keep for crash reporting) ───────────────────────────────────
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile
+
+# ── Gson / JSON (if used anywhere) ───────────────────────────────────────────
+-keepclassmembers,allowobfuscation class * {
+    @com.google.gson.annotations.SerializedName <fields>;
+}

--- a/micopay/frontend/android/app/src/main/AndroidManifest.xml
+++ b/micopay/frontend/android/app/src/main/AndroidManifest.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:allowBackup="false"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+    android:allowBackup="false"
+    android:dataExtractionRules="@xml/data_extraction_rules"
+    android:fullBackupContent="@xml/backup_rules"
+    android:networkSecurityConfig="@xml/network_security_config"
+    android:usesCleartextTraffic="false"
+    android:icon="@mipmap/ic_launcher"
+    android:label="@string/app_name"
+    android:roundIcon="@mipmap/ic_launcher_round"
+    android:supportsRtl="true"
+    android:theme="@style/AppTheme">
         <activity
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation|density"
             android:name=".MainActivity"

--- a/micopay/frontend/android/app/src/main/res/xml/backup_rules.xml
+++ b/micopay/frontend/android/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <!--
+        MicoPay handles Stellar keypairs, JWT tokens, and USDC balances.
+        Nothing in shared prefs, databases, or files should ever be backed up
+        to Google Drive — a restored device must re-authenticate from scratch.
+    -->
+    <exclude domain="sharedpref" path="." />
+    <exclude domain="database" path="." />
+    <exclude domain="file" path="." />
+    <exclude domain="external" path="." />
+    <exclude domain="root" path="." />
+</full-backup-content>

--- a/micopay/frontend/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/micopay/frontend/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+
+    <cloud-backup>
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="root" path="." />
+    </cloud-backup>
+
+    <device-transfer>
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="root" path="." />
+    </device-transfer>
+
+</data-extraction-rules>

--- a/micopay/frontend/android/app/src/main/res/xml/network_security_config.xml
+++ b/micopay/frontend/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+
+    <!--
+        Production: system CAs only, no cleartext ever.
+        This blocks all HTTP traffic in release builds.
+    -->
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+
+    <!--
+        Debug only: trust user-installed CAs so Charles/Proxyman
+        can intercept for local dev. Never ships in release.
+    -->
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
+
+</network-security-config>

--- a/micopay/frontend/android/gradle.properties
+++ b/micopay/frontend/android/gradle.properties
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx2048m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/micopay/frontend/android/gradle.properties
+++ b/micopay/frontend/android/gradle.properties
@@ -20,3 +20,9 @@ org.gradle.jvmargs=-Xmx1536m
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
+
+# Enable R8 full mode for release builds
+android.enableR8.fullMode=true
+
+# Disable Jetifier if you're on full AndroidX (speeds up builds)
+android.enableJetifier=false

--- a/micopay/frontend/capacitor.config.ts
+++ b/micopay/frontend/capacitor.config.ts
@@ -7,9 +7,7 @@ const config: CapacitorConfig = {
   server: {
     androidScheme: 'https',
   },
-  android: {
-    allowMixedContent: true,
-  },
 };
+
 
 export default config;

--- a/micopay/frontend/package-lock.json
+++ b/micopay/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "micopay-frontend",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "micopay-frontend",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "@aparajita/capacitor-secure-storage": "^8.0.0",
         "@capacitor-mlkit/barcode-scanning": "^8.1.0",
@@ -157,6 +157,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -967,6 +968,7 @@
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.3.4.tgz",
       "integrity": "sha512-CqRQCkb6HXxcx/N7s+hHTN6ef2CmamFiRMITwm4qB840ph56mS42bzUgn6tKCP+RZjdDweiRHj9ytDDeN6jFag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -1128,6 +1130,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1176,6 +1179,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2741,6 +2745,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3045,6 +3050,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -3062,6 +3068,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3072,6 +3079,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3652,6 +3660,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6711,6 +6720,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6762,6 +6772,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6992,6 +7003,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7001,6 +7013,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8356,6 +8369,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8500,6 +8514,7 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/micopay/frontend/package.json
+++ b/micopay/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "micopay-frontend",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Closes #89 
## Changes

### Signing
- Configured release signing via `keystore.properties` (gitignored — never committed)
- Added `keystore.properties.example` as a template for teammates
- Release build now produces `app-release.apk` (signed) instead of `app-release-unsigned.apk`

### R8 / Minification
- Enabled `minifyEnabled true` and `shrinkResources true` in release build
- Switched from `proguard-android.txt` to `proguard-android-optimize.txt`
- Added full ProGuard keep rules for Capacitor core, MLKit barcode scanning,
  secure storage, geolocation, status bar and app plugins

### Network Security
- Added `network_security_config.xml` — HTTPS only, no cleartext in production
- Debug builds allow user-installed CAs for local proxy tools (Charles/Proxyman)
- Set `android:usesCleartextTraffic="false"` in AndroidManifest
- Removed `allowMixedContent: true` from `capacitor.config.ts`

### Backup Hardening
- Added `backup_rules.xml` (Android 6–11) — excludes all sharedpref, database, file, external and root domains
- Added `data_extraction_rules.xml` (Android 12+) — same exclusions for cloud backup and device transfer
- Wired both in AndroidManifest alongside existing `allowBackup="false"`

### Versioning
- Aligned `versionName` to `"1.0.0"` in `build.gradle`
- Aligned `version` to `"1.0.0"` in `package.json`
- `versionCode` strategy: increment by 1 per Play Store upload

### Build
- Increased Gradle daemon heap from 1536m to 2048m to prevent OOM crash on full clean builds
- Enabled `android.enableR8.fullMode=true` in `gradle.properties`

## Acceptance Criteria
- [x] Signed release build generates reproducibly
- [x] Versioning supports clean upgrades
- [x] Production build uses HTTPS and no local endpoints
- [x] Secrets/JWT/keypairs are not backed up insecurely
- [x] Store readiness checklist is complete

## Test Notes
- Built with `./gradlew clean assembleRelease`
- Verified with `apksigner verify --verbose app-release.apk`
- v2 scheme verified: true (required for Android 7+)
