### PR TITLE
feat: expired trade refund flow (#71)

### DIFF
--- a/micopay/backend/src/routes/trades.ts
+++ b/micopay/backend/src/routes/trades.ts
@@ -143,6 +143,18 @@ export async function tradeRoutes(app: FastifyInstance) {
   });
 
   /**
+   * POST /trades/:id/refund
+   *
+   * Buyer triggers on-chain refund for an expired trade. Calls refund() on the Soroban contract
+   * and transitions the trade to 'refunded' status. Returns `{ status, refund_tx_hash }`.
+   * Errors use `{ error, message }` via the global Fastify error handler.
+   */
+  app.post('/trades/:id/refund', async (request) => {
+    const { id } = request.params as { id: string };
+    return tradeService.refundTrade(request, id, request.user.id);
+  });
+
+  /**
    * GET /trades/:id/audit
    * Ordered trade transition audit trail for support/ops.
    */

--- a/micopay/backend/src/services/stellar.service.ts
+++ b/micopay/backend/src/services/stellar.service.ts
@@ -217,6 +217,88 @@ export async function callReleaseOnChain(params: {
 }
 
 /**
+ * Call the escrow contract's refund() function on testnet.
+ * Anyone can call after timeout. trade_id = sha256(secret_hash_bytes).
+ */
+export async function callRefundOnChain(params: {
+  request: FastifyRequest;
+  tradeIdBytes: Buffer;
+}): Promise<{ txHash: string }> {
+  const {
+    Contract, TransactionBuilder, Networks, Keypair,
+    nativeToScVal, rpc: rpcModule,
+  } = await import('@stellar/stellar-sdk');
+
+  const { tradeIdBytes } = params;
+
+  const rpc = new rpcModule.Server(config.stellarRpcUrl);
+  const keypair = Keypair.fromSecret(config.platformSecretKey);
+  const platformAddress = keypair.publicKey();
+
+  const account = await rpc.getAccount(platformAddress);
+  const contract = new Contract(config.escrowContractId);
+
+  const tx = new TransactionBuilder(account, {
+    fee: '1000000',
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      contract.call(
+        'refund',
+        nativeToScVal(tradeIdBytes, { type: 'bytes' }),
+      ),
+    )
+    .setTimeout(60)
+    .build();
+
+  let prepared;
+  try {
+    prepared = await rpc.prepareTransaction(tx);
+  } catch (err: any) {
+    params.request.log.error({ err: err.message, category: 'stellar.tx' }, '[Stellar] Refund simulation failed');
+    throw new Error(`Refund simulation failed: ${err.message}. Check if trade exists in contract.`);
+  }
+
+  prepared.sign(keypair);
+
+  const sendResult = await rpc.sendTransaction(prepared);
+  if (sendResult.status === 'ERROR') {
+    params.request.log.error({ detail: sendResult.errorResult, category: 'stellar.tx' }, '[Stellar] Refund send failed');
+    throw new Error(`Refund send failed: ${JSON.stringify(sendResult.errorResult)}`);
+  }
+
+  const txHash = sendResult.hash;
+
+  const horizonUrl = `https://horizon-testnet.stellar.org/transactions/${txHash}`;
+  for (let i = 0; i < 15; i++) {
+    await new Promise((r) => setTimeout(r, 2000));
+    try {
+      const res = await fetch(horizonUrl);
+      if (res.ok) {
+        const data = await res.json() as { successful: boolean };
+        if (data.successful) {
+          params.request.log.info({ tx_hash: txHash, category: 'stellar.tx' }, '[Stellar] Refund confirmed');
+          return { txHash };
+        }
+        throw new UpstreamError(
+          'STELLAR_REFUND_FAILED',
+          'La transacción de reembolso falló en la blockchain.',
+          `Refund transaction failed on-chain: ${txHash}`
+        );
+      }
+    } catch (err: any) {
+      if (err.message.includes('failed on-chain')) throw err;
+    }
+  }
+
+  throw new UpstreamError(
+    'STELLAR_REFUND_TIMEOUT',
+    'La transacción de reembolso está tardando más de lo esperado.',
+    `Refund tx ${txHash} not confirmed within 30s`
+  );
+}
+
+/**
  * Legacy mock used when MOCK_STELLAR=true.
  */
 export async function verifyLockOnChain(

--- a/micopay/backend/src/services/trade.service.ts
+++ b/micopay/backend/src/services/trade.service.ts
@@ -4,7 +4,7 @@ import pino from 'pino';
 import { generateTradeSecret, encryptSecret, decryptSecret } from './secret.service.js';
 import { createHash } from 'crypto';
 import type { FastifyRequest } from 'fastify';
-import { callLockOnChain, callReleaseOnChain, verifyLockOnChain, assertNotReplayed } from './stellar.service.js';
+import { callLockOnChain, callReleaseOnChain, callRefundOnChain, verifyLockOnChain, assertNotReplayed } from './stellar.service.js';
 import {
   NotFoundError,
   ForbiddenError,
@@ -645,6 +645,93 @@ export async function cancelTrade(
       toState: 'cancelled',
       actor: userId,
       metadata: { cancel_reason: reason ?? null },
+    }, error);
+    throw error;
+  }
+}
+
+/**
+ * Response shape for POST /trades/:id/refund.
+ */
+export interface RefundTradeResult {
+  status: 'refunded';
+  refund_tx_hash: string;
+}
+
+export async function refundTrade(
+  request: FastifyRequest,
+  tradeId: string,
+  userId: string,
+): Promise<RefundTradeResult> {
+  request.log.info({ trade_id: tradeId, user_id: userId, category: 'trade.lifecycle' }, '[trade] Refunding trade');
+  let fromState = UNKNOWN_STATE;
+
+  try {
+    const trade = await db.getOne('SELECT * FROM trades WHERE id = $1', [tradeId]);
+    if (!trade) throw new NotFoundError('Trade not found');
+    fromState = trade.status;
+
+    if (trade.buyer_id !== userId) {
+      throw new ForbiddenError('Solo el comprador puede solicitar un reembolso');
+    }
+
+    if (!trade.lock_tx_hash) {
+      throw new ConflictError('No hay fondos en cadena para reembolsar en este intercambio');
+    }
+
+    if (new Date(trade.expires_at) > new Date()) {
+      throw new TradeStateError(
+        'TRADE_NOT_EXPIRED',
+        'El intercambio aún no ha expirado. Espera a que venza el tiempo.',
+        `Trade ${tradeId} has not expired yet (expires at ${trade.expires_at})`
+      );
+    }
+
+    if (['completed', 'cancelled', 'refunded'].includes(trade.status)) {
+      throw new ConflictError(`No se puede reembolsar un intercambio en estado ${trade.status}`);
+    }
+
+    let refundTxHash: string;
+
+    if (!config.mockStellar) {
+      const secretHashBytes = Buffer.from(trade.secret_hash, 'hex');
+      const tradeIdBytes = createHash('sha256').update(secretHashBytes).digest();
+
+      const result = await callRefundOnChain({ request, tradeIdBytes });
+      refundTxHash = result.txHash;
+    } else {
+      refundTxHash = `mock_refund_${Date.now()}`;
+    }
+
+    await assertNotReplayed(refundTxHash, 'trade/refund', userId);
+
+    await db.execute(
+      `UPDATE trades
+       SET status = 'refunded',
+           release_tx_hash = $2,
+           completed_at = NOW()
+       WHERE id = $1`,
+      [tradeId, refundTxHash],
+    );
+
+    await insertTradeAuditEvent({
+      tradeId,
+      fromState,
+      toState: 'refunded',
+      actor: userId,
+      metadata: {
+        success: true,
+        refund_tx_hash: refundTxHash,
+      },
+    });
+
+    return { status: 'refunded', refund_tx_hash: refundTxHash };
+  } catch (error) {
+    await logTransitionFailure({
+      tradeId,
+      fromState,
+      toState: 'refunded',
+      actor: userId,
     }, error);
     throw error;
   }

--- a/micopay/frontend/src/pages/History.tsx
+++ b/micopay/frontend/src/pages/History.tsx
@@ -8,6 +8,7 @@ const STATUS_LABEL: Record<string, { label: string; color: string; bg: string }>
   pending:   { label: 'Pendiente',  color: 'text-outline',   bg: 'bg-outline/10' },
   cancelled: { label: 'Cancelado',  color: 'text-error',     bg: 'bg-error/10' },
   expired:   { label: 'Expirado',   color: 'text-outline',   bg: 'bg-outline/10' },
+  refunded:  { label: 'Reembolsado', color: 'text-[#8b5cf6]', bg: 'bg-[#8b5cf6]/10' },
 };
 
 interface HistoryProps {
@@ -21,6 +22,7 @@ const FILTERS = [
   { id: 'completed', label: 'Completados' },
   { id: 'cancelled', label: 'Cancelados' },
   { id: 'expired', label: 'Expirados' },
+  { id: 'refunded', label: 'Reembolsados' },
 ];
 
 const History = ({ onBack, onSelectTrade, token }: HistoryProps) => {

--- a/micopay/frontend/src/pages/TradeDetail.tsx
+++ b/micopay/frontend/src/pages/TradeDetail.tsx
@@ -4,6 +4,7 @@ import {
   fetchTradeDetail,
   completeTrade,
   cancelTradeRequest,
+  refundTradeRequest,
   TradeDetailResponse,
 } from '../services/api';
 
@@ -21,6 +22,17 @@ function getToken(): string | null {
     return parsed?.buyer?.token ?? parsed?.seller?.token ?? null;
   } catch {
     return null;
+  }
+}
+
+function isCurrentUserBuyer(tradeBuyerId: string): boolean {
+  try {
+    const raw = localStorage.getItem('micopay_users');
+    if (!raw) return false;
+    const parsed = JSON.parse(raw);
+    return parsed?.buyer?.id === tradeBuyerId;
+  } catch {
+    return false;
   }
 }
 
@@ -63,6 +75,7 @@ const STATUS_CONFIG: Record<string, { label: string; color: string; icon: string
   completed: { label: 'Completado', color: '#22c55e', icon: 'check_circle' },
   cancelled: { label: 'Cancelado', color: '#ef4444', icon: 'cancel' },
   expired: { label: 'Expirado', color: '#6b7280', icon: 'schedule' },
+  refunded: { label: 'Reembolsado', color: '#8b5cf6', icon: 'undo' },
 };
 
 function TradeStateBadge({ status }: { status: string }) {
@@ -323,7 +336,7 @@ function CancelledView() {
   );
 }
 
-function ExpiredView() {
+function ExpiredView({ isBuyer, onRefund, refunding, trade }: { isBuyer: boolean; onRefund: () => void; refunding: boolean; trade: TradeDetailData }) {
   return (
     <div className="flex flex-col items-center text-center">
       <div className="w-16 h-16 rounded-full bg-gray-100 flex items-center justify-center mb-6">
@@ -333,8 +346,88 @@ function ExpiredView() {
       </div>
       <h2 className="text-2xl font-bold text-on-surface mb-2">Operación expirada</h2>
       <p className="text-on-surface-variant mb-6">
-        El tiempo para completar esta operación ha expirado. Tus fondos fueron devueltos.
+        El tiempo para completar esta operación ha expirado.
       </p>
+
+      <div className="bg-surface-container-low rounded-xl p-4 w-full mb-6">
+        <div className="flex justify-between items-center mb-2">
+          <span className="text-sm text-on-surface-variant">Monto</span>
+          <span className="font-bold text-on-surface">${trade.amount_mxn} MXN</span>
+        </div>
+        <div className="flex justify-between items-center">
+          <span className="text-sm text-on-surface-variant">Comisión</span>
+          <span className="text-sm text-on-surface">${trade.platform_fee_mxn} MXN</span>
+        </div>
+      </div>
+
+      {isBuyer ? (
+        <button
+          onClick={onRefund}
+          disabled={refunding}
+          className="w-full py-3 rounded-xl bg-primary text-white font-semibold hover:opacity-90 transition-opacity flex items-center justify-center gap-2 disabled:opacity-50"
+        >
+          {refunding ? (
+            <>
+              <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
+              Procesando reembolso…
+            </>
+          ) : (
+            <>
+              <span className="material-symbols-outlined" style={{ fontVariationSettings: '"FILL" 1' }}>undo</span>
+              Recuperar fondos
+            </>
+          )}
+        </button>
+      ) : (
+        <Link
+          to="/"
+          className="w-full py-3 rounded-xl bg-primary text-white font-semibold hover:opacity-90 transition-opacity text-center"
+        >
+          Volver al inicio
+        </Link>
+      )}
+    </div>
+  );
+}
+
+function RefundedView({ trade }: { trade: TradeDetailData }) {
+  const STELLAR_EXPLORER = 'https://stellar.expert/explorer/testnet/tx';
+  const refundTxHash = trade.release_tx_hash;
+
+  return (
+    <div className="flex flex-col items-center text-center">
+      <div className="w-16 h-16 rounded-full bg-purple-100 flex items-center justify-center mb-6">
+        <span className="material-symbols-outlined text-purple-600 text-3xl" style={{ fontVariationSettings: '"FILL" 1' }}>
+          undo
+        </span>
+      </div>
+      <h2 className="text-2xl font-bold text-on-surface mb-2">Fondos reembolsados</h2>
+      <p className="text-on-surface-variant mb-6">
+        Los fondos fueron devueltos exitosamente. El tiempo para completar la operación había expirado.
+      </p>
+
+      <div className="bg-surface-container-low rounded-xl p-4 w-full mb-6">
+        <div className="flex justify-between items-center mb-2">
+          <span className="text-sm text-on-surface-variant">Monto</span>
+          <span className="font-bold text-on-surface">${trade.amount_mxn} MXN</span>
+        </div>
+        <div className="flex justify-between items-center">
+          <span className="text-sm text-on-surface-variant">Comisión</span>
+          <span className="text-sm text-on-surface">${trade.platform_fee_mxn} MXN</span>
+        </div>
+      </div>
+
+      {refundTxHash && (
+        <a
+          href={`${STELLAR_EXPLORER}/${refundTxHash}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary text-sm font-semibold hover:underline mb-6 flex items-center gap-1"
+        >
+          Ver transacción de reembolso en Stellar
+          <span className="material-symbols-outlined text-sm">open_in_new</span>
+        </a>
+      )}
 
       <Link
         to="/"
@@ -423,6 +516,96 @@ function NetworkError({ onRetry }: { onRetry: () => void }) {
   );
 }
 
+// ── Refund confirmation dialog ─────────────────────────────────────────────
+
+function RefundConfirmDialog({
+  open,
+  amount,
+  fee,
+  onClose,
+  onConfirm,
+  submitting,
+  error,
+}: {
+  open: boolean;
+  amount: number;
+  fee: number;
+  onClose: () => void;
+  onConfirm: () => void;
+  submitting: boolean;
+  error: string | null;
+}) {
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-end sm:items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="refund-title"
+    >
+      <div className="w-full max-w-md rounded-2xl bg-surface p-6 shadow-xl border border-outline-variant/20">
+        <h2 id="refund-title" className="font-headline text-lg font-bold text-on-surface">
+          Recuperar fondos
+        </h2>
+        <p className="mt-3 text-sm text-on-surface-variant leading-relaxed">
+          El intercambio expiró. Al recuperar los fondos se ejecutará el reembolso en la
+          blockchain de Stellar. Esta operación tiene un costo de gas fee en XLM.
+        </p>
+
+        <div className="mt-4 bg-surface-container-low rounded-xl p-4">
+          <div className="flex justify-between items-center mb-2">
+            <span className="text-sm text-on-surface-variant">Monto a recuperar</span>
+            <span className="font-bold text-on-surface">${amount} MXN</span>
+          </div>
+          <div className="flex justify-between items-center mb-2">
+            <span className="text-sm text-on-surface-variant">Comisión de la operación</span>
+            <span className="text-sm text-on-surface">${fee} MXN</span>
+          </div>
+          <div className="flex justify-between items-center pt-2 border-t border-outline-variant/20">
+            <span className="text-sm font-semibold text-on-surface-variant">Total devuelto</span>
+            <span className="font-bold text-primary">${amount} MXN</span>
+          </div>
+          <p className="mt-3 text-xs text-on-surface-variant">
+            * Se aplicará un gas fee en XLM por la transacción en Stellar. Los fondos en MXN
+            serán devueltos a tu cuenta.
+          </p>
+        </div>
+
+        {error && (
+          <div className="mt-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-900">
+            <p>{error}</p>
+            <p className="mt-2 text-xs">
+              <a href="mailto:soporte@micopay.app" className="font-semibold underline">
+                Contactar soporte
+              </a>
+            </p>
+          </div>
+        )}
+
+        <div className="mt-6 flex gap-2 justify-end">
+          <button
+            type="button"
+            className="rounded-lg px-4 py-2 text-sm font-semibold text-primary hover:bg-surface-container-low"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            disabled={submitting}
+            className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+            onClick={onConfirm}
+          >
+            {submitting ? 'Procesando…' : 'Sí, recuperar fondos'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ── Main component ──────────────────────────────────────────────────────────
 
 export default function TradeDetail() {
@@ -431,6 +614,9 @@ export default function TradeDetail() {
   const [trade, setTrade] = useState<TradeDetailData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<'not_found' | 'forbidden' | 'network' | null>(null);
+  const [showRefundConfirm, setShowRefundConfirm] = useState(false);
+  const [isRefunding, setIsRefunding] = useState(false);
+  const [refundError, setRefundError] = useState<string | null>(null);
 
   const fetchTrade = useCallback(async () => {
     if (!id) return;
@@ -493,6 +679,37 @@ export default function TradeDetail() {
     fetchTrade(); // Refresh to get completed state
   };
 
+  // Handle refund
+  const handleRefundConfirm = async () => {
+    if (!trade) return;
+    const token = getToken();
+    if (!token) return;
+
+    setIsRefunding(true);
+    setRefundError(null);
+    try {
+      await refundTradeRequest(trade.id, token);
+      setShowRefundConfirm(false);
+      fetchTrade();
+    } catch (e: any) {
+      setRefundError(e.message || 'Error al procesar el reembolso. Intenta de nuevo.');
+    } finally {
+      setIsRefunding(false);
+    }
+  };
+
+  const handleRefundClick = () => {
+    setRefundError(null);
+    setShowRefundConfirm(true);
+  };
+
+  const handleCloseRefundConfirm = () => {
+    if (!isRefunding) {
+      setShowRefundConfirm(false);
+      setRefundError(null);
+    }
+  };
+
   // Loading state
   if (loading) {
     return (
@@ -534,6 +751,8 @@ export default function TradeDetail() {
     return null;
   }
 
+  const isBuyer = isCurrentUserBuyer(trade.buyer_id ?? '');
+
   // Render state-specific view
   const renderStateView = () => {
     switch (trade.status) {
@@ -550,7 +769,9 @@ export default function TradeDetail() {
       case 'cancelled':
         return <CancelledView />;
       case 'expired':
-        return <ExpiredView />;
+        return <ExpiredView isBuyer={isBuyer} onRefund={handleRefundClick} refunding={isRefunding} trade={trade} />;
+      case 'refunded':
+        return <RefundedView trade={trade} />;
       default:
         return <PendingView trade={trade} onCancel={handleCancel} />;
     }
@@ -584,10 +805,23 @@ export default function TradeDetail() {
         {renderStateView()}
 
         {/* Support link visible in all states */}
-        {trade.status !== 'completed' && trade.status !== 'cancelled' && trade.status !== 'expired' && (
+        {trade.status !== 'completed' && trade.status !== 'cancelled' && trade.status !== 'expired' && trade.status !== 'refunded' && (
           <SupportLink />
         )}
       </main>
+
+      {/* Refund confirmation dialog */}
+      {trade.status === 'expired' && (
+        <RefundConfirmDialog
+          open={showRefundConfirm}
+          amount={trade.amount_mxn}
+          fee={trade.platform_fee_mxn ?? 0}
+          onClose={handleCloseRefundConfirm}
+          onConfirm={handleRefundConfirm}
+          submitting={isRefunding}
+          error={refundError}
+        />
+      )}
     </div>
   );
 }

--- a/micopay/frontend/src/services/api.ts
+++ b/micopay/frontend/src/services/api.ts
@@ -163,6 +163,21 @@ export async function completeTrade(
   await http.post(`/trades/${tradeId}/complete`, {}, authHeaders(buyerToken));
 }
 
+export interface RefundTradeResponse {
+  status: 'refunded';
+  refund_tx_hash: string;
+}
+
+export async function refundTradeRequest(tradeId: string, token: string): Promise<RefundTradeResponse> {
+  try {
+    const res = await http.post(`/trades/${tradeId}/refund`, {}, authHeaders(token));
+    return res.data as RefundTradeResponse;
+  } catch (e: unknown) {
+    const { message } = extractApiErrorPayload(e);
+    throw new Error(message);
+  }
+}
+
 export interface TradeHistoryItem {
   id: string;
   status: string;


### PR DESCRIPTION
## Summary

Implements the expired trade refund flow for the Trade Detail screen. When a trade expires, the buyer can now recover their funds by triggering an on-chain refund via the Soroban contract.

## Changes

### Backend
- **`stellar.service.ts`** — Added `callRefundOnChain()` to invoke the Soroban escrow contract's `refund()` function after the timeout ledger has been reached
- **`trade.service.ts`** — Added `refundTrade()` with full validation: verifies the caller is the buyer, the trade is past expiration, and on-chain funds exist (`lock_tx_hash`). Transitions the trade to `refunded` status and stores the refund transaction hash
- **`routes/trades.ts`** — Added `POST /trades/:id/refund` endpoint

### Frontend
- **`TradeDetail.tsx`**:
  - `ExpiredView` now shows a "Recuperar fondos" button when the current user is the buyer
  - `RefundConfirmDialog` provides a two-step confirmation with amount breakdown and gas fee warning
  - `RefundedView` displays the terminal refunded state with the Stellar transaction hash and explorer link
  - Added `refunded` to `STATUS_CONFIG` with purple styling and `undo` icon
- **`api.ts`** — Added `refundTradeRequest()` function and `RefundTradeResponse` type
- **`History.tsx`** — Added `refunded` filter tab ("Reembolsados") and status label

## Acceptance Criteria

- [x] Expired trade shows "Recuperar fondos" button for the buyer
- [x] Flow completes calling `refund()` on Soroban and updates state to `refunded`
- [x] Refund tx hash visible in detail view
- [x] Refund errors (already claimed, not yet expired) show a clear message
- [x] `refunded` state appears in history with visual distinction from `completed`

Closes #71
