### PR TITLE
test: end-to-end smoke test for core P2P flow

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,11 +7,10 @@
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "build": "tsc",
-    "test": "vitest --run",
+    "test": "vitest run",
     "seed": "tsx src/scripts/seed.ts",
     "db:setup": "npm run seed",
-    "db:reset": "npx tsx -e \"import('./src/db/schema.js').then(m => m.query('DROP TABLE IF EXISTS merchants, swap_history, bazaar_quotes, bazaar_intents, agent_history, x402_payments CASCADE'))\"",
-    "test": "vitest run"
+    "db:reset": "npx tsx -e \"import('./src/db/schema.js').then(m => m.query('DROP TABLE IF EXISTS merchants, swap_history, bazaar_quotes, bazaar_intents, agent_history, x402_payments CASCADE'))\""
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.86.1",
@@ -33,6 +32,7 @@
     "typescript": "^5.7.3"
   },
   "devDependencies": {
+    "fast-check": "^4.8.0",
     "pino-pretty": "^13.0.0",
     "vitest": "^4.1.5"
   }

--- a/apps/api/src/__tests__/p2p.test.ts
+++ b/apps/api/src/__tests__/p2p.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import Fastify, { FastifyInstance } from "fastify";
+import fastifyJwt from "@fastify/jwt";
+import { tradeRoutes } from "../routes/trades.js";
+import db from "../db/schema.js";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("../db/schema.js", () => ({
+  default: {
+    getOne: vi.fn(),
+    getMany: vi.fn(),
+    execute: vi.fn(),
+  },
+  getOne: vi.fn(),
+  getMany: vi.fn(),
+  execute: vi.fn(),
+}));
+
+vi.mock("../config.js", () => ({
+  config: {
+    jwtSecret: "test_secret",
+    mockStellar: true,
+    secretEncryptionKey:
+      "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff", // 32 bytes hex
+  },
+}));
+
+vi.mock("../services/stellar.service.js", () => ({
+  callLockOnChain: vi.fn().mockResolvedValue({ txHash: "mock_lock_tx" }),
+  callReleaseOnChain: vi.fn().mockResolvedValue({ txHash: "mock_release_tx" }),
+  verifyLockOnChain: vi.fn().mockResolvedValue(true),
+}));
+
+// ── Test Suite ─────────────────────────────────────────────────────────────
+
+describe("P2P Trade Flow Smoke Test", () => {
+  let app: FastifyInstance;
+  let buyerToken: string;
+  let sellerToken: string;
+  const buyerId = "11111111-1111-1111-1111-111111111111";
+  const sellerId = "22222222-2222-2222-2222-222222222222";
+  const tradeId = "33333333-3333-3333-3333-333333333333";
+
+  beforeAll(async () => {
+    app = Fastify();
+    app.register(fastifyJwt, { secret: "test_secret" });
+
+    // Manual route registration to avoid full app complexity
+    app.register(tradeRoutes);
+    await app.ready();
+
+    buyerToken = app.jwt.sign({ id: buyerId, stellar_address: "GBUYER..." });
+    sellerToken = app.jwt.sign({ id: sellerId, stellar_address: "GSELLER..." });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("completes a full P2P trade lifecycle", async () => {
+    const mockTrade = {
+      id: tradeId,
+      seller_id: sellerId,
+      buyer_id: buyerId,
+      amount_mxn: 500,
+      amount_stroops: "5000000000",
+      platform_fee_mxn: 4,
+      secret_hash: "hash123",
+      status: "pending",
+      expires_at: new Date(Date.now() + 3600000).toISOString(),
+    };
+
+    // 1. Create Trade (Buyer initiated)
+    (db.getOne as any)
+      .mockResolvedValueOnce({ id: sellerId, stellar_address: "GSELLER..." }) // seller check
+      .mockResolvedValueOnce({ id: buyerId, stellar_address: "GBUYER..." }) // buyer check
+      .mockResolvedValueOnce(mockTrade); // insert result
+
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/trades",
+      headers: { Authorization: `Bearer ${buyerToken}` },
+      payload: { seller_id: sellerId, amount_mxn: 500 },
+    });
+
+    expect(createRes.statusCode).toBe(201);
+    expect(JSON.parse(createRes.body).trade.id).toBe(tradeId);
+
+    // 2. Lock Trade (Seller calls lock after verifying buyer address)
+    (db.getOne as any)
+      .mockResolvedValueOnce(mockTrade) // getTrade
+      .mockResolvedValueOnce({ id: buyerId, stellar_address: "GBUYER..." }); // get buyer address
+
+    const lockRes = await app.inject({
+      method: "POST",
+      url: `/trades/${tradeId}/lock`,
+      headers: { Authorization: `Bearer ${sellerToken}` },
+    });
+
+    expect(lockRes.statusCode).toBe(200);
+    expect(JSON.parse(lockRes.body).status).toBe("locked");
+
+    // 3. Reveal Trade (Seller confirms receipt of physical cash)
+    (db.getOne as any).mockResolvedValueOnce({
+      ...mockTrade,
+      status: "locked",
+    });
+
+    const revealRes = await app.inject({
+      method: "POST",
+      url: `/trades/${tradeId}/reveal`,
+      headers: { Authorization: `Bearer ${sellerToken}` },
+    });
+
+    expect(revealRes.statusCode).toBe(200);
+    expect(JSON.parse(revealRes.body).status).toBe("revealing");
+
+    // 4. Get Secret (Seller retrieves secret to show QR code to buyer)
+    // We need real encryption data here because tradeService.getTradeSecret calls decryptSecret
+    const { encryptSecret } = await import("../services/secret.service.js");
+    const { encrypted, nonce } = encryptSecret("my-secret-preimage");
+
+    (db.getOne as any).mockResolvedValueOnce({
+      ...mockTrade,
+      status: "revealing",
+      secret_enc: encrypted,
+      secret_nonce: nonce,
+    });
+
+    const secretRes = await app.inject({
+      method: "GET",
+      url: `/trades/${tradeId}/secret`,
+      headers: { Authorization: `Bearer ${sellerToken}` },
+    });
+
+    expect(secretRes.statusCode).toBe(200);
+    const secretData = JSON.parse(secretRes.body);
+    expect(secretData.secret).toBe("my-secret-preimage");
+    expect(secretData.qr_payload).toContain("my-secret-preimage");
+
+    // 5. Complete Trade (Buyer releases on-chain funds using the secret)
+    (db.getOne as any).mockResolvedValueOnce({
+      ...mockTrade,
+      status: "revealing",
+      secret_enc: encrypted,
+      secret_nonce: nonce,
+    });
+
+    const completeRes = await app.inject({
+      method: "POST",
+      url: `/trades/${tradeId}/complete`,
+      headers: { Authorization: `Bearer ${buyerToken}` },
+    });
+
+    expect(completeRes.statusCode).toBe(200);
+    expect(JSON.parse(completeRes.body).status).toBe("completed");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "typescript": "^5.7.3"
       },
       "devDependencies": {
+        "fast-check": "^4.8.0",
         "pino-pretty": "^13.0.0",
         "vitest": "^4.1.5"
       }
@@ -1682,27 +1683,6 @@
         "tailwindcss": "4.2.4"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -1769,14 +1749,6 @@
       "os": [
         "darwin"
       ]
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2007,31 +1979,6 @@
       },
       "engines": {
         "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/aria-query": {
@@ -2559,14 +2506,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "license": "MIT",
@@ -2749,9 +2688,9 @@
       }
     },
     "node_modules/fast-check": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
-      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
       "dev": true,
       "funding": [
         {
@@ -3397,7 +3336,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3419,17 +3357,6 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -3726,22 +3653,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "license": "MIT",
@@ -3812,14 +3723,6 @@
       "peerDependencies": {
         "react": "^19.2.5"
       }
-    },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",


### PR DESCRIPTION
This PR adds a comprehensive end-to-end smoke test for the core P2P trading lifecycle.

The test covers:
- Trade creation by buyer.
- Trade locking by seller.
- Trade reveal by seller (after cash receipt).
- Secret retrieval by seller.
- Trade completion by buyer (on-chain release simulation).

I've also added `fast-check` to the API dependencies to support future property-based testing and fixed the existing test environment.

Closes #72