### PR TITLE
docs(wave6): drop money-amount questions from research issues

### DIFF
--- a/docs/AUDIT_APK_WAVE6.md
+++ b/docs/AUDIT_APK_WAVE6.md
@@ -296,29 +296,29 @@ respuesta estructurada, útil y sin datos personales sensibles.
 > agregados se vacían en [`VALIDATION_DRIPS.md`](./VALIDATION_DRIPS.md).
 
 **Principio privacy-first:** no pedir ni aceptar nombres reales, teléfonos, direcciones, wallets,
-llaves privadas, documentos, comprobantes, hashes de transacción, ingresos exactos, saldos exactos
-ni información financiera delicada. Las respuestas deben usar rangos, país/región general y relatos
-anonimizados.
+llaves privadas, documentos, comprobantes, hashes de transacción ni información financiera.
+**No se piden montos de dinero** (ni siquiera en rangos): nada de ingresos, saldos ni tamaños de
+transacción. Las respuestas usan solo país/región general y relatos anonimizados.
 
 ### Issues iniciales sugeridos
 
 1. **Market validation: contexto de cash-out**
    - Objetivo: entender si convertir saldo digital/remesa/cripto a efectivo es un problema real.
-   - Respuestas esperadas: país o región general, frecuencia aproximada, rango de monto, método
-     actual, principal fricción (comisión, tiempo, confianza, liquidez, seguridad).
+   - Respuestas esperadas: país o región general, frecuencia aproximada, método actual, principal
+     fricción (comisión, tiempo, confianza, liquidez, seguridad). Sin montos.
    - Aceptación: respuesta completa sin datos sensibles y etiquetada para análisis agregado.
 
 2. **Market validation: contexto de cash-in / depósito**
    - Objetivo: entender si ingresar efectivo a una wallet/saldo digital resuelve un dolor real.
-   - Respuestas esperadas: caso de uso, método actual, frecuencia, rango de monto, barreras de
-     confianza y disponibilidad de agentes/comercios.
+   - Respuestas esperadas: caso de uso, método actual, frecuencia, barreras de confianza y
+     disponibilidad de agentes/comercios. Sin montos.
    - Aceptación: respuesta completa sin datos sensibles y etiquetada para análisis agregado.
 
 3. **Market validation: perspectiva de proveedor de liquidez**
    - Objetivo: validar si un usuario/comercio aceptaría operar como proveedor de liquidez (app
      agnóstica de rol, D-2).
    - Respuestas esperadas: tipo de comercio general, país/región, motivación, riesgos percibidos,
-     comisión esperada, límites razonables y condiciones para confiar.
+     comisión esperada (en %) y condiciones para confiar. Sin montos.
    - Aceptación: respuesta completa sin datos sensibles y etiquetada para análisis agregado.
 
 4. **Product validation: onboarding de wallet no-custodial**

--- a/docs/VALIDATION_DRIPS.md
+++ b/docs/VALIDATION_DRIPS.md
@@ -3,8 +3,8 @@
 > **Purpose:** aggregate, anonymized synthesis of the research issues (V-1…V-5). The full
 > issue text lives in [`WAVE6_RESEARCH_ISSUES.md`](./WAVE6_RESEARCH_ISSUES.md).
 >
-> ⚠️ **Never copy personal data here.** Only patterns, ranges, and counts. No names, no
-> contact info, no exact figures, no screenshots with sensitive data.
+> ⚠️ **Never copy personal data here.** Only patterns and counts. No amounts of money, no
+> names, no contact info, no screenshots with sensitive data.
 
 ---
 

--- a/docs/WAVE6_RESEARCH_ISSUES.md
+++ b/docs/WAVE6_RESEARCH_ISSUES.md
@@ -26,9 +26,10 @@
 
 > ⚠️ **Privacy-first — do not share personal or sensitive data.** No real names, phone
 > numbers, addresses, wallet addresses, private keys, documents, receipts, transaction
-> hashes, exact income, exact balances, or sensitive financial details. Use **ranges**,
-> a **general country/region**, and **anonymized** stories only. Answers that include
-> sensitive data will be edited or removed.
+> hashes, or financial details. **We do not ask for any amounts of money** — please don't
+> share income, balances, or transaction sizes (not even as ranges). Share only a
+> **general country/region** and **anonymized** stories. Answers that include sensitive
+> data will be edited or removed.
 
 ---
 
@@ -45,7 +46,6 @@ Understand whether converting digital balance (remittance / crypto / digital mon
 ```
 - Country / general region:
 - How often you (or people you know) need to turn digital money into cash: (e.g. weekly / monthly / rarely)
-- Typical amount range: (e.g. <500 MXN / 500–2,000 / 2,000–10,000 / >10,000)
 - Current method you use: (ATM, exchange, a person, a shop, Western Union, etc.)
 - Main friction today: (fee / time / trust / liquidity / safety / availability)
 - One short anonymized story of a time this was painful:
@@ -58,7 +58,7 @@ Understand whether converting digital balance (remittance / crypto / digital mon
 
 ### Out of scope
 - Specific product feedback (that's V-4 / V-5).
-- Any personal identifiers or exact financial figures.
+- Any personal identifiers or amounts of money.
 
 ---
 
@@ -77,7 +77,6 @@ pain — the reverse direction of V-1.
 - Use case where you'd want to deposit cash into a wallet: (top up, save, pay online, send to family, etc.)
 - Current method you use today (if any):
 - How often: (weekly / monthly / rarely)
-- Typical amount range: (e.g. <500 / 500–2,000 / 2,000–10,000 / >10,000)
 - Trust barriers: what would make you hesitate to hand cash to an agent/shop?
 - Availability: are there nearby people/shops you'd trust for this? (yes / no / not sure)
 ```
@@ -89,7 +88,7 @@ pain — the reverse direction of V-1.
 
 ### Out of scope
 - Specific product UI feedback (that's V-4 / V-5).
-- Any personal identifiers or exact financial figures.
+- Any personal identifiers or amounts of money.
 
 ---
 
@@ -112,8 +111,7 @@ Validate whether a regular user or a small business would be willing to act as a
 - If a small business: general type (shop, pharmacy, food, services…). If an individual: skip.
 - Main motivation: (extra income, foot traffic, helping neighbors, curiosity…)
 - Perceived risks: (fake payment, robbery, legal, not getting paid, reputation…)
-- Commission you'd expect to charge: (as a % range, e.g. 1–3%)
-- Reasonable limits: max amount per operation / per day you'd be comfortable with (range)
+- Commission you'd expect to charge: (as a %, e.g. 1–3%)
 - What would make you trust the system enough to try it once:
 ```
 
@@ -124,7 +122,7 @@ Validate whether a regular user or a small business would be willing to act as a
 
 ### Out of scope
 - Onboarding UX feedback (that's V-4).
-- Any personal identifiers or exact financial figures.
+- Any personal identifiers or amounts of money.
 
 ---
 


### PR DESCRIPTION
Quita las preguntas de montos de dinero de los issues de validación (V-1…V-5), incluso por rangos. Decisión de producto: no recolectar ingresos, saldos ni tamaños de transacción. Se mantiene la comisión como % en V-3. Refleja el cambio en `WAVE6_RESEARCH_ISSUES.md`, `AUDIT_APK_WAVE6.md` §7 y `VALIDATION_DRIPS.md`.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)