### PR TITLE
docs(wave6): frame research issues for SDF presentation

### DIFF
--- a/docs/VALIDATION_DRIPS.md
+++ b/docs/VALIDATION_DRIPS.md
@@ -1,41 +1,101 @@
-# Wave 6 — Validation learnings (aggregate)
+# Wave 6 — Validation results & SDF presentation prep
 
-> **Purpose:** aggregate, anonymized synthesis of the research issues (V-1…V-5). The full
-> issue text lives in [`WAVE6_RESEARCH_ISSUES.md`](./WAVE6_RESEARCH_ISSUES.md).
+> **Purpose:** turn the answers from the research issues (V-1…V-5) into an aggregate,
+> anonymized synthesis we can present to the **Stellar Development Foundation (SDF)** as
+> evidence of real-world demand, supply, usability, and trust for a Stellar-based
+> cash-in/cash-out network in emerging markets.
+>
+> Full issue text: [`WAVE6_RESEARCH_ISSUES.md`](./WAVE6_RESEARCH_ISSUES.md) ·
+> Wave 6 plan: [`AUDIT_APK_WAVE6.md`](./AUDIT_APK_WAVE6.md).
 >
 > ⚠️ **Never copy personal data here.** Only patterns and counts. No amounts of money, no
 > names, no contact info, no screenshots with sensitive data.
 
 ---
 
-## How to use this file
+## The story we're proving for the SDF
 
-When a research issue (V-1…V-5) gets a complete answer, add the **anonymized takeaway** to the
-matching section below as a bullet. Tag each bullet with a friction/trust label in brackets,
-e.g. `[friction: fee]`, `[trust: verified-badge]`. Keep one line per insight.
+A funding/grant case for MicoPay on Stellar rests on four claims. The five research issues
+each supply evidence for one of them:
 
----
+| Claim | Backed by | One-line thesis |
+|---|---|---|
+| **1. Demand exists** | V-1 (cash-out) + V-2 (cash-in) | People have a real, recurring pain converting digital ↔ cash |
+| **2. Supply exists** | V-3 (liquidity providers) | Real people/businesses would provide the cash for a commission |
+| **3. Stellar is usable** | V-4 (non-custodial onboarding) | Mainstream users can handle a self-custodial Stellar wallet |
+| **4. Trust / PMF** | V-5 (flow trust) | Users would actually adopt and complete the flow |
 
-## V-1 · Cash-out context
-_(no responses yet)_
-
-## V-2 · Cash-in / deposit context
-_(no responses yet)_
-
-## V-3 · Liquidity provider perspective
-_(no responses yet)_
-
-## V-4 · Non-custodial wallet onboarding
-_(no responses yet)_
-
-## V-5 · Trust in the cash-in/cash-out flow
-_(no responses yet)_
+> Put together: **demand + supply + usable tech + trust = a credible case that a Stellar P2P
+> cash network serves the financially underserved.**
 
 ---
 
-## Summary of decisions this validation should inform
+## Macro context (TAM — from public data, not from this survey)
 
-- Whether cash-out / cash-in demand is strong enough to prioritize one direction first.
-- What trust signals a provider needs to show (feeds P1-2 map + P0-3 balance + receipts).
-- How mandatory wallet backup should be at sign-up (feeds P0-5 / open question 3).
-- Minimum info shown before a user commits to an operation (feeds Stage 2 UI work).
+The *size* of the problem comes from public sources; cite them in the deck. The survey adds
+*willingness and trust*, which public data can't give. Approximate figures to verify and cite:
+
+- Remittances to Mexico: ~US$60B+/year (cite World Bank / Banxico, latest year).
+- Share of population unbanked / underbanked in Mexico: majority (cite ENIF / World Bank Findex).
+- (Add the equivalent figure for any other region respondents come from.)
+
+> The survey's job is **not** to size the market — it's to show that, on top of a known huge
+> market, real people are **willing** to use this specific Stellar-based solution.
+
+---
+
+## Metrics to extract per issue
+
+Fill these in as answers arrive. Keep counts and percentages only.
+
+| Metric | From | Target signal |
+|---|---|---|
+| % reporting cash-out as a recurring need | V-1 | demand |
+| Top cash-out friction (ranked) | V-1 | what to fix first |
+| % with a real cash-in use case | V-2 | bidirectional demand |
+| Main cash-in trust barrier (ranked) | V-2 | trust design |
+| % willing to be a liquidity provider | V-3 | supply |
+| Acceptable commission range (in %) | V-3 | unit economics |
+| % who find non-custodial backup clear (vs confusing) | V-4 | onboarding viability |
+| Top trust blocker in the flow | V-5 | PMF / UX priority |
+| Top reason to abandon the flow | V-5 | drop-off risk |
+| Regions represented (count by region) | all | geographic spread |
+| Total respondents (N) | all | sample size |
+
+---
+
+## Methodology note (state this honestly in the deck)
+
+- **Convenience sample**, self-selected via the Drips program — **directional/qualitative
+  signal, not a representative study.** Report it as such; do not present as statistically
+  rigorous.
+- Anonymized and privacy-first: **no personal data and no money amounts collected.**
+- Sample size is small; report `N` plainly and let the patterns speak.
+
+---
+
+## Aggregate findings (fill as answers come in)
+
+### V-1 · Cash-out context
+_(no responses yet)_
+
+### V-2 · Cash-in / deposit context
+_(no responses yet)_
+
+### V-3 · Liquidity provider perspective
+_(no responses yet)_
+
+### V-4 · Non-custodial wallet onboarding
+_(no responses yet)_
+
+### V-5 · Trust in the cash-in/cash-out flow
+_(no responses yet)_
+
+---
+
+## How findings feed Wave 6 product work
+
+- Cash-out vs cash-in demand → which direction to prioritize first.
+- Trust signals a provider must show → P1-2 (map), P0-3 (real balance), receipts.
+- Clarity of wallet backup → how mandatory to make it at sign-up (P0-5 / open question 3).
+- Minimum info before committing → Stage 2 UI work.

--- a/docs/WAVE6_RESEARCH_ISSUES.md
+++ b/docs/WAVE6_RESEARCH_ISSUES.md
@@ -42,6 +42,9 @@
 Understand whether converting digital balance (remittance / crypto / digital money) into
 **physical cash** is a real, recurring problem worth solving.
 
+**Validates (SDF angle):** user-side **demand** for cash-out on Stellar.
+→ Metric: % of respondents reporting cash-out as a recurring need, and their top friction.
+
 ### What to answer (copy this template into a comment and fill it in)
 ```
 - Country / general region:
@@ -70,6 +73,10 @@ Understand whether converting digital balance (remittance / crypto / digital mon
 ### Objective
 Understand whether putting **physical cash into a digital wallet / balance** solves a real
 pain — the reverse direction of V-1.
+
+**Validates (SDF angle):** the problem is **bidirectional** (cash-in too), widening the
+addressable use case beyond cash-out.
+→ Metric: % with a real cash-in use case, and their main trust barrier.
 
 ### What to answer (copy this template into a comment and fill it in)
 ```
@@ -103,6 +110,10 @@ pain — the reverse direction of V-1.
 ### Objective
 Validate whether a regular user or a small business would be willing to act as a
 **liquidity provider** (the human cash point).
+
+**Validates (SDF angle):** the **supply side** — that real people/businesses would provide
+liquidity, so the P2P network can actually function (not just demand with no one to serve it).
+→ Metric: % willing to be a provider, and the acceptable commission % range.
 
 ### What to answer (copy this template into a comment and fill it in)
 ```
@@ -139,6 +150,10 @@ Validate whether a regular user or a small business would be willing to act as a
 Validate whether a typical user understands **creating/importing a wallet** and the
 **responsibility of backing it up**, and what would make that step feel trustworthy.
 
+**Validates (SDF angle):** that Stellar's **non-custodial model is usable by mainstream
+users**, not only crypto-native people — a key adoption question for self-custody on Stellar.
+→ Metric: % who find the key-backup responsibility clear vs confusing, and what builds trust.
+
 ### How to participate
 Look at the onboarding/registration flow (or the description above) and answer below. If you
 run the app locally, do **not** share your real keys, addresses, or screenshots containing them.
@@ -171,6 +186,10 @@ run the app locally, do **not** share your real keys, addresses, or screenshots 
 ### Objective
 Validate whether a user would **trust** the core flow: pick a liquidity provider, see the
 commission, use a QR/receipt, and complete the operation.
+
+**Validates (SDF angle):** **trust / product-market fit** in the end-to-end experience —
+whether real users would actually adopt it, not just like the idea.
+→ Metric: top trust blockers and the top reason users would abandon the flow.
 
 ### How to participate
 Walk through the flow (choose provider → see fee → QR/receipt → complete) in the app or from


### PR DESCRIPTION
Hace que la data de validación salga lista para presentar a la SDF: cada issue (V-1…V-5) declara qué valida (demanda/oferta/usabilidad de Stellar/confianza) y la métrica que produce; `VALIDATION_DRIPS.md` se vuelve el doc de síntesis + preparación de la presentación (narrativa de 4 claims, tabla de métricas, nota honesta de metodología, contexto macro/TAM de fuentes públicas).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)