### PR TITLE
feat(issues): GitHub Issue Forms for Wave 6 research (V-1…V-5)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Wave 6 plan (read first)
+    url: https://github.com/ericmt-98/micopay-protocol/blob/main/docs/AUDIT_APK_WAVE6.md
+    about: The Wave 6 source of truth — findings, issue queue, and acceptance criteria.
+  - name: Research issues overview
+    url: https://github.com/ericmt-98/micopay-protocol/blob/main/docs/WAVE6_RESEARCH_ISSUES.md
+    about: What the validation (research) issues are and how they feed the SDF case.

--- a/.github/ISSUE_TEMPLATE/research_v1_cashout.yml
+++ b/.github/ISSUE_TEMPLATE/research_v1_cashout.yml
@@ -1,0 +1,66 @@
+name: "[Research] V-1 · Cash-out context"
+description: "No code, no PR. Share your experience turning digital money into physical cash. Privacy-first."
+title: "[Research] Cash-out — <your region>"
+labels: ["research"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for contributing! This is a **research** issue — **no code, no pull request**.
+
+        ⚠️ **Privacy-first:** do not share names, phone numbers, addresses, wallet addresses, private keys, or **any amounts of money** (not even ranges). Use a general region and anonymized stories only. Answers with sensitive data will be edited or removed.
+
+        **What this validates (SDF):** user-side **demand** for cash-out on Stellar.
+        Responses accepted in English or Spanish.
+  - type: input
+    id: region
+    attributes:
+      label: Country / general region
+      placeholder: e.g. Mexico, northern region
+    validations:
+      required: true
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: How often do you (or people you know) need to turn digital money into cash?
+      options:
+        - Weekly
+        - Monthly
+        - Rarely
+        - Never
+    validations:
+      required: true
+  - type: input
+    id: method
+    attributes:
+      label: Current method you use
+      placeholder: ATM, exchange, a person, a shop, Western Union, etc.
+    validations:
+      required: true
+  - type: dropdown
+    id: friction
+    attributes:
+      label: Main friction today
+      options:
+        - Fee
+        - Time
+        - Trust
+        - Liquidity
+        - Safety
+        - Availability
+    validations:
+      required: true
+  - type: textarea
+    id: story
+    attributes:
+      label: One short anonymized story of a time this was painful
+      placeholder: No names or personal details, please.
+    validations:
+      required: false
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Confirmation
+      options:
+        - label: I did not include names, contact info, wallet/keys, or any amounts of money.
+          required: true

--- a/.github/ISSUE_TEMPLATE/research_v2_cashin.yml
+++ b/.github/ISSUE_TEMPLATE/research_v2_cashin.yml
@@ -1,0 +1,68 @@
+name: "[Research] V-2 · Cash-in / deposit context"
+description: "No code, no PR. Share your experience putting physical cash into a digital wallet. Privacy-first."
+title: "[Research] Cash-in — <your region>"
+labels: ["research"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for contributing! This is a **research** issue — **no code, no pull request**.
+
+        ⚠️ **Privacy-first:** no names, phone numbers, addresses, wallet addresses, private keys, or **any amounts of money** (not even ranges). General region and anonymized stories only.
+
+        **What this validates (SDF):** the problem is **bidirectional** (cash-in too), widening the use case.
+        Responses accepted in English or Spanish.
+  - type: input
+    id: region
+    attributes:
+      label: Country / general region
+      placeholder: e.g. Mexico, northern region
+    validations:
+      required: true
+  - type: textarea
+    id: usecase
+    attributes:
+      label: Use case where you'd want to deposit cash into a wallet
+      placeholder: top up, save, pay online, send to family, etc.
+    validations:
+      required: true
+  - type: input
+    id: method
+    attributes:
+      label: Current method you use today (if any)
+    validations:
+      required: false
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: How often
+      options:
+        - Weekly
+        - Monthly
+        - Rarely
+        - Never
+    validations:
+      required: true
+  - type: textarea
+    id: trust_barrier
+    attributes:
+      label: Trust barriers — what would make you hesitate to hand cash to an agent/shop?
+    validations:
+      required: true
+  - type: dropdown
+    id: availability
+    attributes:
+      label: Are there nearby people/shops you'd trust for this?
+      options:
+        - "Yes"
+        - "No"
+        - Not sure
+    validations:
+      required: true
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Confirmation
+      options:
+        - label: I did not include names, contact info, wallet/keys, or any amounts of money.
+          required: true

--- a/.github/ISSUE_TEMPLATE/research_v3_provider.yml
+++ b/.github/ISSUE_TEMPLATE/research_v3_provider.yml
@@ -1,0 +1,71 @@
+name: "[Research] V-3 · Liquidity provider perspective"
+description: "No code, no PR. Would you act as a liquidity provider (the human cash point)? Privacy-first."
+title: "[Research] Liquidity provider — <your region>"
+labels: ["research"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for contributing! This is a **research** issue — **no code, no pull request**.
+
+        MicoPay is **role-agnostic**: any user can act as a liquidity provider (hand over cash, earn a commission) — there is no separate "merchant" app.
+
+        ⚠️ **Privacy-first:** no names, contact info, addresses, wallet/keys, or **amounts of money**. A commission **percentage** is fine; do not share cash amounts. General region and anonymized stories only.
+
+        **What this validates (SDF):** the **supply side** — that real people/businesses would provide liquidity.
+        Responses accepted in English or Spanish.
+  - type: input
+    id: region
+    attributes:
+      label: Country / general region
+    validations:
+      required: true
+  - type: dropdown
+    id: willing
+    attributes:
+      label: Would you consider providing liquidity (giving cash, receiving digital balance)?
+      options:
+        - "Yes"
+        - "No"
+        - Maybe
+    validations:
+      required: true
+  - type: input
+    id: actor
+    attributes:
+      label: If a small business, general type (shop, pharmacy, food, services). If an individual, write "individual".
+    validations:
+      required: false
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Main motivation
+      placeholder: extra income, foot traffic, helping neighbors, curiosity…
+    validations:
+      required: true
+  - type: textarea
+    id: risks
+    attributes:
+      label: Perceived risks
+      placeholder: fake payment, robbery, legal, not getting paid, reputation…
+    validations:
+      required: true
+  - type: input
+    id: commission
+    attributes:
+      label: Commission you'd expect to charge (as a %, e.g. 1–3%)
+    validations:
+      required: false
+  - type: textarea
+    id: trust
+    attributes:
+      label: What would make you trust the system enough to try it once
+    validations:
+      required: true
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Confirmation
+      options:
+        - label: I did not include names, contact info, wallet/keys, or any amounts of money (commission % is fine).
+          required: true

--- a/.github/ISSUE_TEMPLATE/research_v4_onboarding.yml
+++ b/.github/ISSUE_TEMPLATE/research_v4_onboarding.yml
@@ -1,0 +1,70 @@
+name: "[Research] V-4 · Non-custodial wallet onboarding"
+description: "No code, no PR. Does the create/import + backup flow make sense to you? Privacy-first."
+title: "[Research] Onboarding — <your region>"
+labels: ["research"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for contributing! This is a **research** issue — **no code, no pull request**.
+
+        MicoPay is **non-custodial**: the wallet (a Stellar keypair) is created on your device; the private key never leaves the phone, and you are responsible for backing it up.
+
+        ⚠️ **Privacy-first:** do **not** share real keys, addresses, or screenshots containing them. No amounts of money.
+
+        **What this validates (SDF):** that Stellar's **non-custodial model is usable** by mainstream users.
+        Responses accepted in English or Spanish.
+  - type: dropdown
+    id: clarity
+    attributes:
+      label: Is it clear that YOU hold the key and YOU must back it up?
+      options:
+        - Clear
+        - Somewhat clear
+        - Confusing
+    validations:
+      required: true
+  - type: textarea
+    id: clarity_why
+    attributes:
+      label: Why? (what made it clear or confusing)
+    validations:
+      required: false
+  - type: textarea
+    id: fear
+    attributes:
+      label: Biggest doubt or fear about a non-custodial wallet
+    validations:
+      required: true
+  - type: textarea
+    id: trust
+    attributes:
+      label: What text, step, or reassurance would make you trust this onboarding
+    validations:
+      required: true
+  - type: dropdown
+    id: preference
+    attributes:
+      label: Preference
+      options:
+        - Create a new wallet
+        - Import an existing Stellar key
+        - No preference
+    validations:
+      required: true
+  - type: dropdown
+    id: backup
+    attributes:
+      label: Should backing up the key be mandatory during sign-up, or optional?
+      options:
+        - Mandatory
+        - Optional
+    validations:
+      required: true
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Confirmation
+      options:
+        - label: I did not include real keys, personal addresses, screenshots with sensitive data, or any amounts of money.
+          required: true

--- a/.github/ISSUE_TEMPLATE/research_v5_trust.yml
+++ b/.github/ISSUE_TEMPLATE/research_v5_trust.yml
@@ -1,0 +1,53 @@
+name: "[Research] V-5 · Trust in the cash-in/cash-out flow"
+description: "No code, no PR. Would you trust picking a provider, seeing the fee, using a QR/receipt? Privacy-first."
+title: "[Research] Flow trust — <your region>"
+labels: ["research"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for contributing! This is a **research** issue — **no code, no pull request**.
+
+        Think about the core flow: pick a liquidity provider → see the commission → use a QR/receipt → complete the operation.
+
+        ⚠️ **Privacy-first:** no names, contact info, addresses, wallet/keys, or **amounts of money**. General region and anonymized stories only.
+
+        **What this validates (SDF):** **trust / product-market fit** in the end-to-end experience.
+        Responses accepted in English or Spanish.
+  - type: textarea
+    id: trust_points
+    attributes:
+      label: At which point would you trust the flow most? Least?
+    validations:
+      required: true
+  - type: textarea
+    id: min_info
+    attributes:
+      label: Minimum information you need to SEE before handing over money/cash
+    validations:
+      required: true
+  - type: textarea
+    id: verified_signals
+    attributes:
+      label: Signals that would make a provider feel "verified" and trustworthy
+    validations:
+      required: true
+  - type: textarea
+    id: support
+    attributes:
+      label: What support/help would you expect if something goes wrong mid-operation
+    validations:
+      required: false
+  - type: textarea
+    id: abandon
+    attributes:
+      label: Top reason you might ABANDON the flow before finishing
+    validations:
+      required: true
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Confirmation
+      options:
+        - label: I did not include names, contact info, wallet/keys, or any amounts of money.
+          required: true


### PR DESCRIPTION
Agrega plantillas de GitHub Issue Form para las 5 validaciones de Wave 6. Cada respuesta se convierte en su propio issue estructurado (una respuesta = un issue = una contribución Drips), auto-etiquetado `research`. Los campos fuerzan estructura y privacidad (sin montos, sin datos personales) y cada formulario declara qué valida para la SDF.

Las plantillas deben estar en `main` para aparecer en "New Issue".

🤖 Generated with [Claude Code](https://claude.com/claude-code)