### PR TITLE
docs(wave6): align research docs (10 issues, first-person, PR delivery)

### DIFF
--- a/docs/AUDIT_APK_WAVE6.md
+++ b/docs/AUDIT_APK_WAVE6.md
@@ -226,22 +226,24 @@ lo demás.
 - **B-5 (Dockerfile/guía de deploy)** → trabajo interno de maintainer/integrator. Roza Risk
   Controls de la guía ("no exponer credenciales de deploy en Waves tempranas"). No publicar como
   issue de contribuidor Drips; manejarlo internamente.
-- **§7 validación de mercado/producto (5 issues: V-1…V-5)** → SÍ se publican como issues de Drips:
-  usar Drips es justamente la ventaja (la comunidad hace el trabajo y se le reconoce). Para que no
-  sean "vague strategy work" cada uno lleva criterio de aceptación concreto (un entregable
-  estructurado que lo cierra). No usan PR ni merge. Labels: `research` (nuevo) · track `wave:docs` ·
-  `complexity: low` · `Stellar Wave`. Ver §7.
+- **§7 validación de mercado/producto (10 issues: V-1…V-10)** → publicados como issues de Drips en
+  el milestone *Wave 6: Market & User Validation* (#18). **Entrega por PR** (el asignado agrega su
+  sección en `VALIDATION_DRIPS.md`), experiencia propia (primera persona), un asignado por issue.
+  Labels: `research` · `wave:docs` · `complexity: low` · `Stellar Wave` (el label `research` ya está
+  creado y documentado en `DRIPS_TEAM_GUIDE.md`). Índice: [`WAVE6_RESEARCH_ISSUES.md`](./WAVE6_RESEARCH_ISSUES.md).
 
-| ID | Título corto | Tipo |
-|----|--------------|------|
-| V-1 | Market validation: contexto de cash-out | research |
-| V-2 | Market validation: contexto de cash-in / depósito | research |
-| V-3 | Market validation: perspectiva de proveedor de liquidez | research |
-| V-4 | Product validation: onboarding de wallet no-custodial | research |
-| V-5 | Product validation: confianza en flujo cash-in/cash-out | research |
-
-> ⚠️ **`research` es el único label NUEVO** que hay que crear en el repo (y documentar en
-> `DRIPS_TEAM_GUIDE.md`) antes de abrir V-1…V-5. El resto de labels ya existen.
+| ID | Tema | Issue |
+|----|------|-------|
+| V-1 | Cash-out | #131 |
+| V-2 | Cash-in / depósito | #132 |
+| V-3 | Proveedor de liquidez | #133 |
+| V-4 | Onboarding no-custodial | #134 |
+| V-5 | Confianza en el flujo | #135 |
+| V-6 | Remesas | #138 |
+| V-7 | Alternativas y switching | #139 |
+| V-8 | Comisión justa | #140 |
+| V-9 | Seguridad en persona | #141 |
+| V-10 | Recurrencia y descubrimiento | #142 |
 
 ### 6.3 Orden recomendado de publicar → asignar → mergear
 
@@ -266,10 +268,9 @@ lo demás.
 **Etapa 4 — Decisiones de producto / release:**
 10. **P2-2** y **P2-3** (requieren decisión de producto primero).
 
-**Etapa paralela — Research (V-1…V-5, sin merge, en cualquier momento):**
-- Las 5 de validación corren **en paralelo a todo**: no tienen dependencia de código ni de
-  build, no llevan PR. Solo requieren crear el label `research` primero (ver §6.2 y §7). Se pueden
-  abrir desde el día 1.
+**Etapa paralela — Research (V-1…V-10, en cualquier momento):**
+- Las 10 de validación corren **en paralelo a todo** y ya están publicadas (milestone #18). Cada
+  asignado entrega por **PR** (su sección en `VALIDATION_DRIPS.md`). El label `research` ya existe.
 
 ### 6.4 Política de asignación y merge (de `DRIPS_TEAM_GUIDE.md`)
 
@@ -287,75 +288,48 @@ lo demás.
 ## 7. Validación DRIPs inicial (mercado + producto)
 
 Además de corregir P0/P1, Wave 6 debe validar si MicoPay hace sentido para usuarios reales en
-su país/contexto. Para empezar, se crearán **5 issues iniciales** en DRIPs. Estos issues no
-requieren pull request ni merge: se aceptan como resueltos cuando el participante entrega una
-respuesta estructurada, útil y sin datos personales sensibles.
+su país/contexto. Hay **10 issues de validación publicados (V-1…V-10)** en el milestone
+*Wave 6: Market & User Validation* (#18). **Entrega por PR** (no comentario): el asignado agrega su
+sección `### V-X` en `VALIDATION_DRIPS.md`. Experiencia **propia** (primera persona); un asignado por issue.
 
-> 📄 **Texto completo listo para publicar:** ver [`WAVE6_RESEARCH_ISSUES.md`](./WAVE6_RESEARCH_ISSUES.md)
-> (cuerpo de cada issue, plantillas de respuesta y checklist de publicación). Los aprendizajes
-> agregados se vacían en [`VALIDATION_DRIPS.md`](./VALIDATION_DRIPS.md).
+> 📄 **Índice y reglas:** [`WAVE6_RESEARCH_ISSUES.md`](./WAVE6_RESEARCH_ISSUES.md). Síntesis
+> agregada para la SDF: [`VALIDATION_DRIPS.md`](./VALIDATION_DRIPS.md).
 
 **Principio privacy-first:** no pedir ni aceptar nombres reales, teléfonos, direcciones, wallets,
 llaves privadas, documentos, comprobantes, hashes de transacción ni información financiera.
 **No se piden montos de dinero** (ni siquiera en rangos): nada de ingresos, saldos ni tamaños de
 transacción. Las respuestas usan solo país/región general y relatos anonimizados.
 
-### Issues iniciales sugeridos
+### Los 10 issues (publicados, milestone #18)
 
-1. **Market validation: contexto de cash-out**
-   - Objetivo: entender si convertir saldo digital/remesa/cripto a efectivo es un problema real.
-   - Respuestas esperadas: país o región general, frecuencia aproximada, método actual, principal
-     fricción (comisión, tiempo, confianza, liquidez, seguridad). Sin montos.
-   - Aceptación: respuesta completa sin datos sensibles y etiquetada para análisis agregado.
+| ID | Tema | Issue | Qué valida (SDF) |
+|----|------|-------|------------------|
+| V-1 | Cash-out | #131 | Demanda (digital → efectivo) |
+| V-2 | Cash-in / depósito | #132 | Demanda bidireccional |
+| V-3 | Proveedor de liquidez | #133 | Oferta |
+| V-4 | Onboarding no-custodial | #134 | Stellar self-custody usable |
+| V-5 | Confianza en el flujo | #135 | Confianza / PMF |
+| V-6 | Remesas | #138 | Demanda de remesas cross-border |
+| V-7 | Alternativas y switching | #139 | Diferenciación |
+| V-8 | Comisión justa | #140 | Economía unitaria (% sin montos) |
+| V-9 | Seguridad en persona | #141 | De-risk P2P |
+| V-10 | Recurrencia y descubrimiento | #142 | Retención / PMF |
 
-2. **Market validation: contexto de cash-in / depósito**
-   - Objetivo: entender si ingresar efectivo a una wallet/saldo digital resuelve un dolor real.
-   - Respuestas esperadas: caso de uso, método actual, frecuencia, barreras de confianza y
-     disponibilidad de agentes/comercios. Sin montos.
-   - Aceptación: respuesta completa sin datos sensibles y etiquetada para análisis agregado.
+Las preguntas completas (en primera persona) viven en cada issue.
 
-3. **Market validation: perspectiva de proveedor de liquidez**
-   - Objetivo: validar si un usuario/comercio aceptaría operar como proveedor de liquidez (app
-     agnóstica de rol, D-2).
-   - Respuestas esperadas: tipo de comercio general, país/región, motivación, riesgos percibidos,
-     comisión esperada (en %) y condiciones para confiar. Sin montos.
-   - Aceptación: respuesta completa sin datos sensibles y etiquetada para análisis agregado.
+### Etiquetas y entrega
 
-4. **Product validation: onboarding de wallet no-custodial**
-   - Objetivo: validar si el usuario entiende crear/importar wallet y la responsabilidad de backup.
-   - Respuestas esperadas: claridad del flujo, dudas, miedos, qué texto o paso generaría confianza,
-     preferencia entre crear wallet e importar clave.
-   - Aceptación: feedback accionable sin compartir claves, direcciones personales ni capturas con
-     datos sensibles.
-
-5. **Product validation: confianza en flujo cash-in/cash-out**
-   - Objetivo: validar si el usuario confiaría en elegir un agente, ver comisión, usar QR/recibo y
-     completar la operación.
-   - Respuestas esperadas: puntos de confianza/desconfianza, información mínima que necesita ver,
-     señales de comercio verificado, soporte esperado y razones para abandonar el flujo.
-   - Aceptación: feedback accionable sin datos sensibles y con etiquetas de fricción/confianza.
-
-### Etiquetas — cómo publicarlos en Drips
-
-> Estos 5 **SÍ se publican como issues de Drips**: usar Drips es la ventaja (la comunidad hace el
-> trabajo y se le reconoce). No usan PR ni merge — se cierran cuando el participante entrega la
-> respuesta estructurada que pide el criterio de aceptación. Eso es lo que los saca de "vague
-> strategy work": cada issue tiene un **entregable concreto y verificable**, no una pregunta abierta.
->
-> ⚠️ Los labels propuestos originalmente (`validation:*`, `persona:*`, `country:*`, `pain:*`,
-> `amount:*`, `frequency:*`) **NO existen en el repo** y no se deben inventar issue por issue.
-> En su lugar, crear **un solo label nuevo de forma deliberada** y documentarlo en
-> `DRIPS_TEAM_GUIDE.md` **antes** de abrir los issues:
-> - **`research`** (nuevo) — marca issues de validación de mercado/usuario sin código.
->
-> Cada uno de los 5 issues lleva: `research` · track **`wave:docs`** · `complexity: low` ·
-> `Stellar Wave`. Cero labels que no existan en el repo.
+> Publicados como issues de Drips (la comunidad hace el trabajo y se le reconoce). **Entrega por
+> PR**, no comentario: el bot de Drips rastrea PRs, lo que deja al contribuidor aplicar a más
+> issues mientras se revisa el suyo. El label **`research`** ya está creado y documentado en
+> `DRIPS_TEAM_GUIDE.md`. Cada issue lleva: `research` · `wave:docs` · `complexity: low` ·
+> `Stellar Wave`.
 
 ### Cierre y síntesis
 
-Cada issue individual se puede cerrar cuando la respuesta esté registrada y etiquetada. Los
-aprendizajes se deben resumir de forma agregada (por ejemplo en `docs/VALIDATION_DRIPS.md`) sin
-copiar datos personales ni detalles que identifiquen a participantes.
+Cada issue se cierra al mergear el PR de su asignado (primera persona, sin datos sensibles). Los
+aprendizajes se resumen de forma agregada y anónima en `docs/VALIDATION_DRIPS.md`, sin copiar
+datos personales ni detalles que identifiquen a participantes.
 
 ---
 

--- a/docs/VALIDATION_DRIPS.md
+++ b/docs/VALIDATION_DRIPS.md
@@ -1,11 +1,11 @@
 # Wave 6 — Validation results & SDF presentation prep
 
-> **Purpose:** turn the answers from the research issues (V-1…V-5) into an aggregate,
+> **Purpose:** turn the answers from the 10 research issues (V-1…V-10) into an aggregate,
 > anonymized synthesis we can present to the **Stellar Development Foundation (SDF)** as
 > evidence of real-world demand, supply, usability, and trust for a Stellar-based
 > cash-in/cash-out network in emerging markets.
 >
-> Full issue text: [`WAVE6_RESEARCH_ISSUES.md`](./WAVE6_RESEARCH_ISSUES.md) ·
+> Overview of the issues: [`WAVE6_RESEARCH_ISSUES.md`](./WAVE6_RESEARCH_ISSUES.md) ·
 > Wave 6 plan: [`AUDIT_APK_WAVE6.md`](./AUDIT_APK_WAVE6.md).
 >
 > ⚠️ **Never copy personal data here.** Only patterns and counts. No amounts of money, no
@@ -13,20 +13,30 @@
 
 ---
 
+## How responses land here
+
+Each research issue (V-1…V-10) has **one assignee**. That person shares **their own
+first-person experience** (not a survey of other people) by opening a **PR that adds their
+own `### V-X` section below**. One section per issue → no merge conflicts. The maintainer
+reviews each PR for privacy before merging.
+
+---
+
 ## The story we're proving for the SDF
 
-A funding/grant case for MicoPay on Stellar rests on four claims. The five research issues
-each supply evidence for one of them:
+A funding/grant case for MicoPay on Stellar rests on a few claims. The research issues each
+supply evidence for one of them:
 
 | Claim | Backed by | One-line thesis |
 |---|---|---|
-| **1. Demand exists** | V-1 (cash-out) + V-2 (cash-in) | People have a real, recurring pain converting digital ↔ cash |
-| **2. Supply exists** | V-3 (liquidity providers) | Real people/businesses would provide the cash for a commission |
-| **3. Stellar is usable** | V-4 (non-custodial onboarding) | Mainstream users can handle a self-custodial Stellar wallet |
-| **4. Trust / PMF** | V-5 (flow trust) | Users would actually adopt and complete the flow |
+| **1. Demand exists** | V-1 (cash-out), V-2 (cash-in), V-6 (remittances) | A real, recurring pain converting digital ↔ cash |
+| **2. Supply exists** | V-3 (liquidity providers) | Real people/businesses would provide cash for a commission |
+| **3. It can win** | V-7 (alternatives), V-8 (fair fee) | Better than current options, at a fee users accept |
+| **4. Stellar is usable** | V-4 (non-custodial onboarding) | Mainstream users can handle a self-custodial wallet |
+| **5. Trust / PMF** | V-5 (flow trust), V-9 (safety), V-10 (repeat use) | Users would adopt, feel safe, and come back |
 
-> Put together: **demand + supply + usable tech + trust = a credible case that a Stellar P2P
-> cash network serves the financially underserved.**
+> Put together: **demand + supply + a winning, affordable, usable, trusted experience = a
+> credible case that a Stellar P2P cash network serves the financially underserved.**
 
 ---
 
@@ -50,31 +60,31 @@ Fill these in as answers arrive. Keep counts and percentages only.
 
 | Metric | From | Target signal |
 |---|---|---|
-| % reporting cash-out as a recurring need | V-1 | demand |
-| Top cash-out friction (ranked) | V-1 | what to fix first |
-| % with a real cash-in use case | V-2 | bidirectional demand |
-| Main cash-in trust barrier (ranked) | V-2 | trust design |
-| % willing to be a liquidity provider | V-3 | supply |
-| Acceptable commission range (in %) | V-3 | unit economics |
+| % reporting cash-out as a recurring need · top friction | V-1 | demand |
+| % with a real cash-in use case · main trust barrier | V-2 | bidirectional demand |
+| % willing to provide liquidity · acceptable commission (%) | V-3 | supply / unit economics |
 | % who find non-custodial backup clear (vs confusing) | V-4 | onboarding viability |
-| Top trust blocker in the flow | V-5 | PMF / UX priority |
-| Top reason to abandon the flow | V-5 | drop-off risk |
-| Regions represented (count by region) | all | geographic spread |
-| Total respondents (N) | all | sample size |
+| Top trust blocker · top reason to abandon | V-5 | PMF / drop-off risk |
+| % who receive remittances · would same-day local cash help | V-6 | remittance demand |
+| What they use today · top switch trigger · dealbreaker | V-7 | differentiation |
+| Fair commission % (distribution) · "too high" threshold | V-8 | unit economics |
+| Comfort meeting a stranger · top safety fear · shops vs individuals | V-9 | safety / de-risking |
+| Discovery method · repeat-use (yes/maybe/no) · recommend driver | V-10 | retention / PMF |
+| Regions represented (count by region) · total respondents (N) | all | spread / sample size |
 
 ---
 
 ## Methodology note (state this honestly in the deck)
 
+- **First-person:** each entry is **one contributor's own experience**, not a survey of others.
 - **Convenience sample**, self-selected via the Drips program — **directional/qualitative
-  signal, not a representative study.** Report it as such; do not present as statistically
-  rigorous.
+  signal, not a representative study.** Report it as such; do not present as statistically rigorous.
 - Anonymized and privacy-first: **no personal data and no money amounts collected.**
 - Sample size is small; report `N` plainly and let the patterns speak.
 
 ---
 
-## Aggregate findings (fill as answers come in)
+## Aggregate findings (one `### V-X` section per contributor PR)
 
 ### V-1 · Cash-out context
 _(no responses yet)_
@@ -91,7 +101,21 @@ _(no responses yet)_
 ### V-5 · Trust in the cash-in/cash-out flow
 _(no responses yet)_
 
+### V-6 · Remittances cash-out context
+_(no responses yet)_
+
+### V-7 · Current alternatives & switching
+_(no responses yet)_
+
+### V-8 · Fair commission / fee tolerance
+_(no responses yet)_
+
+### V-9 · Safety meeting in person
+_(no responses yet)_
+
 ### V-10 · Product validation: repeat use & provider discovery
+> Note: submitted in the earlier multi-respondent format (kept as-is). Newer entries are first-person.
+
 Small anonymized sample (N=4; self + 3 peers, convenience sample across Mexico and other Latin American regions):
 
 - Respondent A — Mexico City, Mexico
@@ -128,7 +152,8 @@ Aggregate signal:
 
 ## How findings feed Wave 6 product work
 
-- Cash-out vs cash-in demand → which direction to prioritize first.
-- Trust signals a provider must show → P1-2 (map), P0-3 (real balance), receipts.
+- Cash-out vs cash-in vs remittance demand → which direction to prioritize first.
+- Trust + safety signals a provider must show → P1-2 (map), P0-3 (real balance), receipts.
 - Clarity of wallet backup → how mandatory to make it at sign-up (P0-5 / open question 3).
-- Minimum info before committing → Stage 2 UI work.
+- Fair fee range → pricing/economics decisions.
+- Discovery + minimum info before committing → Stage 2 UI work.

--- a/docs/WAVE6_RESEARCH_ISSUES.md
+++ b/docs/WAVE6_RESEARCH_ISSUES.md
@@ -1,222 +1,48 @@
-# Wave 6 — Research Issues (ready to publish on Drips)
+# Wave 6 — Research (market & user validation) issues
 
-> **Qué es esto:** el texto completo de los 5 issues de validación de mercado/usuario
-> (V-1…V-5) listo para **copiar y pegar como issues de GitHub**. Son los primeros que
-> subimos: no llevan código ni PR, son los más sencillos de completar.
+> **What this is:** an overview of the 10 validation issues (V-1…V-10) that feed the
+> [SDF presentation prep](./VALIDATION_DRIPS.md). The full questions live in each GitHub
+> issue; this file is the index + the rules.
 >
-> **Fuente:** §7 de [`AUDIT_APK_WAVE6.md`](./AUDIT_APK_WAVE6.md). Los aprendizajes se
-> resumen de forma **agregada** en [`VALIDATION_DRIPS.md`](./VALIDATION_DRIPS.md).
->
-> **Idioma:** el texto está en inglés (issues públicos para audiencia Drips). Las
-> respuestas se aceptan en **español o inglés**.
+> Part of the Wave 6 plan: [`AUDIT_APK_WAVE6.md`](./AUDIT_APK_WAVE6.md) §7.
 
 ---
 
-## Antes de publicar (checklist)
+## The model
 
-1. **Crear el label `research`** en el repo (es el único nuevo). Color sugerido: morado.
-   `gh label create research --description "Market/user validation — no code, no PR" --color 8957e5`
-2. Confirmar que existen los labels: `wave:docs`, `complexity: low`, `Stellar Wave`.
-3. Publicar los 5 issues con el cuerpo de abajo. No requieren milestone.
-4. No asignar a un solo contribuidor de forma exclusiva: cada respuesta estructurada es válida.
+- **First-person only.** Each contributor shares **their own** experience — no surveying other
+  people, no invented samples.
+- **One assignee per issue.** People apply via the Drips bot; the maintainer assigns one person
+  per issue; the bot notifies them.
+- **Delivery = PR.** The assignee opens a PR that adds their own `### V-X` section to
+  [`VALIDATION_DRIPS.md`](./VALIDATION_DRIPS.md) (one section per issue → no conflicts). The
+  maintainer reviews for privacy and merges.
+- **Labels:** `research` · `wave:docs` · `complexity: low` · `Stellar Wave`.
 
----
+## Privacy-first (applies to every issue)
 
-## Principio de privacidad (va en CADA issue)
+> ⚠️ No real names, phone numbers, addresses, wallet addresses, private keys, documents,
+> receipts, transaction hashes, or financial details. **We do not ask for any amounts of
+> money** — not even ranges. A commission **percentage** (V-3, V-8) is fine. Share only a
+> **general country/region** and your **own anonymized** experience. Responses in English or Spanish.
 
-> ⚠️ **Privacy-first — do not share personal or sensitive data.** No real names, phone
-> numbers, addresses, wallet addresses, private keys, documents, receipts, transaction
-> hashes, or financial details. **We do not ask for any amounts of money** — please don't
-> share income, balances, or transaction sizes (not even as ranges). Share only a
-> **general country/region** and **anonymized** stories. Answers that include sensitive
-> data will be edited or removed.
+## The 10 issues
 
----
-
-# V-1 · [Research] Market validation: cash-out context
-
-**Labels:** `research` · `wave:docs` · `complexity: low` · `Stellar Wave`
-**Type:** Research issue — no code, no pull request.
-
-### Objective
-Understand whether converting digital balance (remittance / crypto / digital money) into
-**physical cash** is a real, recurring problem worth solving.
-
-**Validates (SDF angle):** user-side **demand** for cash-out on Stellar.
-→ Metric: % of respondents reporting cash-out as a recurring need, and their top friction.
-
-### What to answer (copy this template into a comment and fill it in)
-```
-- Country / general region:
-- How often you (or people you know) need to turn digital money into cash: (e.g. weekly / monthly / rarely)
-- Current method you use: (ATM, exchange, a person, a shop, Western Union, etc.)
-- Main friction today: (fee / time / trust / liquidity / safety / availability)
-- One short anonymized story of a time this was painful:
-```
-
-### Acceptance criteria
-- A complete, structured answer following the template above.
-- No sensitive personal data (see privacy principle).
-- Tagged for aggregate analysis (maintainer adds friction/trust notes on close).
-
-### Out of scope
-- Specific product feedback (that's V-4 / V-5).
-- Any personal identifiers or amounts of money.
-
----
-
-# V-2 · [Research] Market validation: cash-in / deposit context
-
-**Labels:** `research` · `wave:docs` · `complexity: low` · `Stellar Wave`
-**Type:** Research issue — no code, no pull request.
-
-### Objective
-Understand whether putting **physical cash into a digital wallet / balance** solves a real
-pain — the reverse direction of V-1.
-
-**Validates (SDF angle):** the problem is **bidirectional** (cash-in too), widening the
-addressable use case beyond cash-out.
-→ Metric: % with a real cash-in use case, and their main trust barrier.
-
-### What to answer (copy this template into a comment and fill it in)
-```
-- Country / general region:
-- Use case where you'd want to deposit cash into a wallet: (top up, save, pay online, send to family, etc.)
-- Current method you use today (if any):
-- How often: (weekly / monthly / rarely)
-- Trust barriers: what would make you hesitate to hand cash to an agent/shop?
-- Availability: are there nearby people/shops you'd trust for this? (yes / no / not sure)
-```
-
-### Acceptance criteria
-- A complete, structured answer following the template above.
-- No sensitive personal data (see privacy principle).
-- Tagged for aggregate analysis.
-
-### Out of scope
-- Specific product UI feedback (that's V-4 / V-5).
-- Any personal identifiers or amounts of money.
-
----
-
-# V-3 · [Research] Market validation: liquidity provider perspective
-
-**Labels:** `research` · `wave:docs` · `complexity: low` · `Stellar Wave`
-**Type:** Research issue — no code, no pull request.
-
-> Context: MicoPay is **role-agnostic** — any user can act as a liquidity provider (the
-> person who hands over cash and earns a commission), there is no separate "merchant" app.
-
-### Objective
-Validate whether a regular user or a small business would be willing to act as a
-**liquidity provider** (the human cash point).
-
-**Validates (SDF angle):** the **supply side** — that real people/businesses would provide
-liquidity, so the P2P network can actually function (not just demand with no one to serve it).
-→ Metric: % willing to be a provider, and the acceptable commission % range.
-
-### What to answer (copy this template into a comment and fill it in)
-```
-- Country / general region:
-- Would you consider providing liquidity (giving cash, receiving digital balance)? (yes / no / maybe)
-- If a small business: general type (shop, pharmacy, food, services…). If an individual: skip.
-- Main motivation: (extra income, foot traffic, helping neighbors, curiosity…)
-- Perceived risks: (fake payment, robbery, legal, not getting paid, reputation…)
-- Commission you'd expect to charge: (as a %, e.g. 1–3%)
-- What would make you trust the system enough to try it once:
-```
-
-### Acceptance criteria
-- A complete, structured answer following the template above.
-- No sensitive personal data (see privacy principle).
-- Tagged for aggregate analysis.
-
-### Out of scope
-- Onboarding UX feedback (that's V-4).
-- Any personal identifiers or amounts of money.
-
----
-
-# V-4 · [Research] Product validation: non-custodial wallet onboarding
-
-**Labels:** `research` · `wave:docs` · `complexity: low` · `Stellar Wave`
-**Type:** Research issue — no code, no pull request.
-
-> Context: MicoPay is **non-custodial**. The wallet (a Stellar keypair) is created on the
-> user's own device; the private key never leaves the phone. The user is responsible for
-> backing up their key.
-
-### Objective
-Validate whether a typical user understands **creating/importing a wallet** and the
-**responsibility of backing it up**, and what would make that step feel trustworthy.
-
-**Validates (SDF angle):** that Stellar's **non-custodial model is usable by mainstream
-users**, not only crypto-native people — a key adoption question for self-custody on Stellar.
-→ Metric: % who find the key-backup responsibility clear vs confusing, and what builds trust.
-
-### How to participate
-Look at the onboarding/registration flow (or the description above) and answer below. If you
-run the app locally, do **not** share your real keys, addresses, or screenshots containing them.
-
-### What to answer (copy this template into a comment and fill it in)
-```
-- Is it clear that YOU hold the key and YOU must back it up? (clear / confusing / why)
-- Biggest doubt or fear about a non-custodial wallet:
-- What text, step, or reassurance would make you trust this onboarding:
-- Preference: create a new wallet vs import an existing Stellar key — which and why:
-- Should backing up the key be mandatory during sign-up, or optional? Why:
-```
-
-### Acceptance criteria
-- Actionable feedback following the template above.
-- No keys, personal addresses, or screenshots with sensitive data.
-- Tagged for aggregate analysis.
-
-### Out of scope
-- The cash-in/cash-out flow trust (that's V-5).
-- Backend/auth implementation details.
-
----
-
-# V-5 · [Research] Product validation: trust in the cash-in/cash-out flow
-
-**Labels:** `research` · `wave:docs` · `complexity: low` · `Stellar Wave`
-**Type:** Research issue — no code, no pull request.
-
-### Objective
-Validate whether a user would **trust** the core flow: pick a liquidity provider, see the
-commission, use a QR/receipt, and complete the operation.
-
-**Validates (SDF angle):** **trust / product-market fit** in the end-to-end experience —
-whether real users would actually adopt it, not just like the idea.
-→ Metric: top trust blockers and the top reason users would abandon the flow.
-
-### How to participate
-Walk through the flow (choose provider → see fee → QR/receipt → complete) in the app or from
-the description, and answer below.
-
-### What to answer (copy this template into a comment and fill it in)
-```
-- At which point would you trust the flow most? Least?
-- Minimum information you need to SEE before handing over money/cash:
-- Signals that would make a provider feel "verified" and trustworthy:
-- What support/help would you expect if something goes wrong mid-operation:
-- Top reason you might ABANDON the flow before finishing:
-```
-
-### Acceptance criteria
-- Actionable feedback following the template above, with friction/trust points identified.
-- No sensitive personal data (see privacy principle).
-- Tagged for aggregate analysis.
-
-### Out of scope
-- Wallet onboarding (that's V-4).
-- Pricing/economics model design.
-
----
+| ID | Issue | Topic | What it validates (SDF) |
+|----|-------|-------|-------------------------|
+| V-1 | [#131](https://github.com/ericmt-98/micopay-protocol/issues/131) | Cash-out context | User-side demand (digital → cash) |
+| V-2 | [#132](https://github.com/ericmt-98/micopay-protocol/issues/132) | Cash-in / deposit | Bidirectional demand (cash → digital) |
+| V-3 | [#133](https://github.com/ericmt-98/micopay-protocol/issues/133) | Liquidity provider | Supply side (who provides the cash) |
+| V-4 | [#134](https://github.com/ericmt-98/micopay-protocol/issues/134) | Non-custodial onboarding | Stellar self-custody usable by normal users |
+| V-5 | [#135](https://github.com/ericmt-98/micopay-protocol/issues/135) | Trust in the flow | Trust / product-market fit |
+| V-6 | [#138](https://github.com/ericmt-98/micopay-protocol/issues/138) | Remittances cash-out | Cross-border remittance demand |
+| V-7 | [#139](https://github.com/ericmt-98/micopay-protocol/issues/139) | Alternatives & switching | Differentiation vs current options |
+| V-8 | [#140](https://github.com/ericmt-98/micopay-protocol/issues/140) | Fair commission / fee | Unit economics (acceptable fee %) |
+| V-9 | [#141](https://github.com/ericmt-98/micopay-protocol/issues/141) | Safety meeting in person | De-risking P2P adoption |
+| V-10 | [#142](https://github.com/ericmt-98/micopay-protocol/issues/142) | Repeat use & discovery | Retention / sustained usage |
 
 ## After answers come in
 
-Each issue is closed once a complete, structured, privacy-safe answer is recorded. Summarize
-learnings **in aggregate** in [`VALIDATION_DRIPS.md`](./VALIDATION_DRIPS.md) — never copy
-personal data or anything that could identify a participant.
+Each issue closes once its assignee's PR is merged (privacy-safe, first-person). The maintainer
+keeps the aggregate, anonymized synthesis in [`VALIDATION_DRIPS.md`](./VALIDATION_DRIPS.md) —
+never copying personal data or anything that could identify a participant.


### PR DESCRIPTION
Alinea los 3 docs de research con el estado real: 10 issues (V-1…V-10) publicados, experiencia propia (primera persona), entrega por PR (sección propia en VALIDATION_DRIPS.md). WAVE6_RESEARCH_ISSUES.md queda como índice; VALIDATION_DRIPS.md con las 10 secciones + métricas; AUDIT §6/§7 actualizado. Se conserva el aporte V-10 de attyolu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)