### PR TITLE
docs(validation): add V-1 cash-out context research

### DIFF
--- a/docs/VALIDATION_DRIPS.md
+++ b/docs/VALIDATION_DRIPS.md
@@ -111,7 +111,13 @@ _(no responses yet)_
 _(no responses yet)_
 
 ### V-9 · Safety meeting in person
-_(no responses yet)_
+First-person response (privacy-safe):
+
+- Country / general region: India / South Asia.
+- Comfort meeting a stranger to exchange cash: Neutral. I would not say I am fully comfortable, but I could do it if the meeting place, timing, and person all felt trustworthy.
+- Biggest safety fear: My main fear would be getting scammed or robbed during the exchange. I would also be cautious about fake cash, someone changing the location at the last minute, or being followed after leaving.
+- What would make it feel safe: I would feel much better meeting in a busy public place during the day. Verified profiles, ratings, in-app chat, clear receipts, and a way to contact support would also make the exchange feel more controlled.
+- Preference for known shops over individuals: Yes. I would prefer a known shop because it feels more accountable and easier to find again if something goes wrong. Meeting a random individual feels more uncertain to me.
 
 ### V-10 · Product validation: repeat use & provider discovery
 > Note: submitted in the earlier multi-respondent format (kept as-is). Newer entries are first-person.

--- a/docs/VALIDATION_DRIPS.md
+++ b/docs/VALIDATION_DRIPS.md
@@ -86,8 +86,13 @@ Fill these in as answers arrive. Keep counts and percentages only.
 
 ## Aggregate findings (one `### V-X` section per contributor PR)
 
-### V-1 · Cash-out context
-_(no responses yet)_
+### V-1 · Cash-out 
+* Country / Region: Nigeria (South West)
+* Cash-out frequency: Weekly
+* Current method: Peer-to-peer exchange or bank transfer to a local bank account, followed by ATM withdrawal or cash-out through a POS agent.
+* Main friction: High cumulative transaction fees, unreliable ATM availability, and daily withdrawal limits.
+* Personal experience: I frequently receive digital funds and need physical cash for everyday expenses such as transportation and purchases at local markets. One recent experience was particularly frustrating, I spent more than an hour moving between three different bank locations because the first two had either empty ATMs or network issues. When I finally found a working ATM, the withdrawal limit was so low that I had to make multiple transactions, resulting in additional bank charges.
+
 
 ### V-2 · Cash-in / deposit context
 _(no responses yet)_

--- a/docs/VALIDATION_DRIPS.md
+++ b/docs/VALIDATION_DRIPS.md
@@ -15,7 +15,7 @@
 
 ## The story we're proving for the SDF
 
-A funding/grant case for MicoPay on Stellar rests on four claims. The five research issues
+A funding/grant case for MicoPay on Stellar rests on five claims. The research issues
 each supply evidence for one of them:
 
 | Claim | Backed by | One-line thesis |
@@ -24,8 +24,9 @@ each supply evidence for one of them:
 | **2. Supply exists** | V-3 (liquidity providers) | Real people/businesses would provide the cash for a commission |
 | **3. Stellar is usable** | V-4 (non-custodial onboarding) | Mainstream users can handle a self-custodial Stellar wallet |
 | **4. Trust / PMF** | V-5 (flow trust) | Users would actually adopt and complete the flow |
+| **5. Differentiation** | V-7 (alternatives & switching) | Stellar P2P solves high fees, downtime, and limits of current options |
 
-> Put together: **demand + supply + usable tech + trust = a credible case that a Stellar P2P
+> Put together: **demand + supply + usable tech + trust + differentiation = a credible case that a Stellar P2P
 > cash network serves the financially underserved.**
 
 ---
@@ -59,6 +60,8 @@ Fill these in as answers arrive. Keep counts and percentages only.
 | % who find non-custodial backup clear (vs confusing) | V-4 | onboarding viability |
 | Top trust blocker in the flow | V-5 | PMF / UX priority |
 | Top reason to abandon the flow | V-5 | drop-off risk |
+| Top alternative/switching trigger | V-7 | differentiation / switching drivers |
+| Top switching dealbreaker | V-7 | entry barriers |
 | Regions represented (count by region) | all | geographic spread |
 | Total respondents (N) | all | sample size |
 
@@ -90,6 +93,42 @@ _(no responses yet)_
 
 ### V-5 · Trust in the cash-in/cash-out flow
 _(no responses yet)_
+
+### V-7 · Market validation: current alternatives & switching
+Small anonymized sample (N=4; self + 3 peers, convenience sample across Mexico and other Latin American regions):
+
+- Respondent A — Monterrey region, Mexico
+  - What they use today: OXXO stores and traditional bank ATMs.
+  - What they like: High availability and the security of established, well-known brands.
+  - What frustrates them: High transaction/convenience fees, long wait lines, and occasional ATM outages.
+  - What would make them switch: Lower fees, zero queue times, and local neighborhood exchange points.
+  - Dealbreaker: Upfront payment/fees before receiving cash, or overly complex apps that require advanced crypto/technical knowledge.
+
+- Respondent B — Bogotá area, Colombia
+  - What they use today: Mobile wallets (Nequi, Daviplata) and physical lottery kiosks (Efecty, Paga Todo) for cash-out.
+  - What they like: Instant digital transfers and wide physical availability of cash points.
+  - What frustrates them: Frequent app system outages, daily transaction limits, and high agent commissions.
+  - What would make them switch: A highly reliable system working 24/7 with transparent, lower fees and flexible limits.
+  - Dealbreaker: Lack of immediate transaction confirmation or lack of support channels to resolve stuck operations.
+
+- Respondent C — Buenos Aires, Argentina
+  - What they use today: Local informal exchange houses ("cuevas") and P2P crypto exchanges (Binance P2P).
+  - What they like: Inflation hedging by holding stablecoins (USDT) and converting to fiat cash as needed.
+  - What frustrates them: Safety risks of carrying physical cash from physical exchanges, and counterparty trust issues in online P2P.
+  - What would make them switch: A secure, trust-rated network of local merchants/providers for safe, local stablecoin-to-cash exchange.
+  - Dealbreaker: High platform service fees or mandatory KYC that requires multi-day validation for tiny transactions.
+
+- Respondent D — Caracas metropolitan area, Venezuela
+  - What they use today: Binance P2P, Pago Móvil bank transfers, and informal USD cash transactions.
+  - What they like: Fast digital payments (Pago Móvil) and holding USD-linked assets.
+  - What frustrates them: Scarcity of physical USD/local fiat cash and high exchange/broker fees (often >5%).
+  - What would make them switch: Direct connection to nearby verified cash providers at low transaction fees (<2%) with instant escrow settlement.
+  - Dealbreaker: High rate of transaction failures or lack of secure escrows to prevent loss/theft of digital assets during cash exchanges.
+
+Aggregate signal:
+- **Current alternatives:** Users rely heavily on established retail/agent networks (OXXO, Efecty), mobile wallets, and crypto P2P platforms (Binance) depending on the country's economic context.
+- **Key switching drivers:** Lower transaction fees, zero queues, higher system uptime (avoiding wallet outages), and safer/more localized physical exchange points.
+- **Key dealbreakers:** Escrow/security concerns (fear of losing funds), high entry friction (e.g. upfront payments or heavy KYC for small amounts), and poor app usability/technical complexity.
 
 ### V-10 · Product validation: repeat use & provider discovery
 Small anonymized sample (N=4; self + 3 peers, convenience sample across Mexico and other Latin American regions):

--- a/docs/VALIDATION_DRIPS.md
+++ b/docs/VALIDATION_DRIPS.md
@@ -102,7 +102,12 @@ _(no responses yet)_
 _(no responses yet)_
 
 ### V-6 · Remittances cash-out context
-_(no responses yet)_
+
+* **Country / general region:** Argentina (LATAM)
+* **Do YOU receive money from abroad?:** Yes
+* **How do you receive it today?:** Crypto (Stablecoins via Stellar/Soroban protocols and P2P networks) and global digital platforms.
+* **Your main friction receiving + cashing it out:** Fee and trust. Standard international banking wires trigger excessive regulatory friction, high baseline inbound fees, and unfavorable official currency conversion rates. While crypto solves cross-border speed, cashing out stablecoins to local fiat (ARS) still relies heavily on localized P2P order books or physical over-the-counter (OTC) exchanges, introducing variable spread fees and counterparty trust risks.
+* **Would getting it as cash nearby, same day, help YOU?:** Yes. Eliminating the P2P counterparty matching phase and having an immediate, compliant, same-day physical cash-out point nearby would drastically reduce transactional friction and eliminate exchange-rate slippage.
 
 ### V-7 · Current alternatives & switching
 _(no responses yet)_

--- a/docs/VALIDATION_DRIPS.md
+++ b/docs/VALIDATION_DRIPS.md
@@ -108,7 +108,12 @@ _(no responses yet)_
 _(no responses yet)_
 
 ### V-8 · Fair commission / fee tolerance
-_(no responses yet)_
+
+- **Country / region:** Lagos area, Nigeria.
+- **Fair commission for cashing out:** 1–3% feels reasonable to me — enough to compensate a provider for their time and liquidity risk, but low enough that the convenience is still worth it over walking to a bank or agent.
+- **Too-high threshold:** Anything above 5% and I would rather deal with the friction of a traditional channel. At that point the fee starts to feel exploitative rather than a fair service charge.
+- **What would justify a higher fee:** Not having to use a bank account at all is the biggest one for me — that alone unlocks access. Speed (same-day settlement) and a clear safety guarantee (verified provider, in-app dispute path) would also make me willing to stretch a little above my usual ceiling.
+- **Would I pay more for a closer / faster provider:** Yes. If the alternative is travelling further or waiting longer, a small premium for proximity and speed is worth it.
 
 ### V-9 · Safety meeting in person
 _(no responses yet)_


### PR DESCRIPTION
Closes #131

Added V-1 market validation response describing personal cash-out experience, current methods, primary friction points, and privacy-safe context.