### PR TITLE
feat(rate): replace hardcoded XLM→MXN ×20 with live CoinGecko rate

### DIFF
--- a/micopay/backend/src/index.ts
+++ b/micopay/backend/src/index.ts
@@ -10,6 +10,7 @@ import { defiRoutes } from './routes/defi.js';
 import { merchantRoutes } from './routes/merchants.js';
 import { adminRoutes } from './routes/admin.js';
 import { tradeSafetyRoutes } from './routes/trade-safety.js';
+import { rateRoutes } from './routes/rate.js';
 import { AppError } from './utils/errors.js';
 import { Keypair } from '@stellar/stellar-sdk';
 import fastifyStatic from '@fastify/static';
@@ -204,6 +205,7 @@ app.register(defiRoutes, { prefix: '' });
 app.register(merchantRoutes, { prefix: '' });
 app.register(tradeSafetyRoutes, { prefix: '' });
 app.register(adminRoutes, { prefix: '' });
+app.register(rateRoutes, { prefix: '' });
 
 // --- Start server ---
 

--- a/micopay/backend/src/routes/rate.ts
+++ b/micopay/backend/src/routes/rate.ts
@@ -1,0 +1,33 @@
+import type { FastifyInstance } from 'fastify';
+import { UpstreamError } from '../utils/errors.js';
+
+const COINGECKO_URL = 'https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=mxn';
+
+export async function rateRoutes(app: FastifyInstance) {
+  app.get('/rate/xlm-mxn', async (_request, _reply) => {
+    const res = await fetch(COINGECKO_URL, { signal: AbortSignal.timeout(5000) });
+    if (!res.ok) {
+      throw new UpstreamError(
+        'RATE_FETCH_FAILED',
+        'No se pudo obtener la tasa de cambio en este momento.',
+        `CoinGecko responded ${res.status}`,
+        503,
+      );
+    }
+    const data = await res.json() as { stellar?: { mxn?: number } };
+    const rate = data?.stellar?.mxn;
+    if (typeof rate !== 'number' || rate <= 0) {
+      throw new UpstreamError(
+        'RATE_FETCH_FAILED',
+        'No se pudo obtener la tasa de cambio en este momento.',
+        `Unexpected CoinGecko payload: ${JSON.stringify(data)}`,
+        503,
+      );
+    }
+    return {
+      rate,
+      source: 'coingecko',
+      fetchedAt: new Date().toISOString(),
+    };
+  });
+}

--- a/micopay/frontend/src/__tests__/Home.test.tsx
+++ b/micopay/frontend/src/__tests__/Home.test.tsx
@@ -8,12 +8,14 @@ vi.mock('../services/api', () => ({
   getAccountBalance: vi.fn(),
   getCurrentUser: vi.fn(),
   getMerchantTrades: vi.fn(),
+  getXlmMxnRate: vi.fn(),
 }));
 
 const mockGetTradeHistory = vi.mocked(api.getTradeHistory);
 const mockGetAccountBalance = vi.mocked(api.getAccountBalance);
 const mockGetCurrentUser = vi.mocked(api.getCurrentUser);
 const mockGetMerchantTrades = vi.mocked(api.getMerchantTrades);
+const mockGetXlmMxnRate = vi.mocked(api.getXlmMxnRate);
 
 function createProps(overrides = {}) {
   return {
@@ -34,6 +36,7 @@ describe('Home — pending-trades badge', () => {
     mockGetTradeHistory.mockResolvedValue([]);
     mockGetCurrentUser.mockResolvedValue({ verification_status: 'verified' } as any);
     mockGetMerchantTrades.mockResolvedValue([]);
+    mockGetXlmMxnRate.mockResolvedValue({ rate: 18.42, source: 'coingecko', fetchedAt: '2026-06-25T12:00:00Z' });
   });
 
   it('calls getMerchantTrades with merchantToken and "pending"', async () => {
@@ -90,5 +93,35 @@ describe('Home — pending-trades badge', () => {
 
     expect(screen.getByText(/hola, juan/i)).toBeInTheDocument();
     expect(screen.queryByText('0')).not.toBeInTheDocument();
+  });
+});
+
+describe('Home — XLM→MXN rate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAccountBalance.mockResolvedValue({ xlm: '250', address: 'GA7ABCDEF12345' });
+    mockGetTradeHistory.mockResolvedValue([]);
+    mockGetCurrentUser.mockResolvedValue({ verification_status: 'verified' } as any);
+    mockGetMerchantTrades.mockResolvedValue([]);
+  });
+
+  it('displays MXN value computed with the fetched rate', async () => {
+    mockGetXlmMxnRate.mockResolvedValue({ rate: 18.42, source: 'coingecko', fetchedAt: '2026-06-25T12:00:00Z' });
+
+    render(<Home {...createProps()} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/4,605/).length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it('shows tilde prefix when rate fetch fails', async () => {
+    mockGetXlmMxnRate.mockRejectedValue(new Error('Network error'));
+
+    render(<Home {...createProps()} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/~5,000/).length).toBeGreaterThanOrEqual(1);
+    });
   });
 });

--- a/micopay/frontend/src/pages/Home.tsx
+++ b/micopay/frontend/src/pages/Home.tsx
@@ -5,6 +5,7 @@ import {
   getTradeHistory,
   getAccountBalance,
   getMerchantTrades,
+  getXlmMxnRate,
   TradeHistoryItem,
   getCurrentUser,
 } from '../services/api';
@@ -42,6 +43,9 @@ const Home = ({
   const [xlmBalance, setXlmBalance] = useState<string | null>(null);
   const [stellarAddress, setStellarAddress] = useState<string>("");
   const [pendingCount, setPendingCount] = useState(0);
+  const [xlmMxnRate, setXlmMxnRate] = useState<number | null>(null);
+  const [rateLoading, setRateLoading] = useState(true);
+  const [rateError, setRateError] = useState(false);
   const [balanceError, setBalanceError] = useState<MappedApiError | null>(null);
   const [historyError, setHistoryError] = useState<MappedApiError | null>(null);
   const [pendingError, setPendingError] = useState<MappedApiError | null>(null);
@@ -89,12 +93,34 @@ const Home = ({
     loadPendingCount();
   }, [loadPendingCount]);
 
-  // Convert XLM to approx MXN (1 XLM ≈ 20 MXN, demo rate)
-  const mxnBalance = xlmBalance
-    ? (parseFloat(xlmBalance.replace(/,/g, "")) * 20).toLocaleString("es-MX", {
-        maximumFractionDigits: 2,
+  useEffect(() => {
+    let cancelled = false;
+    setRateLoading(true);
+    setRateError(false);
+    getXlmMxnRate()
+      .then((data) => {
+        if (!cancelled) {
+          setXlmMxnRate(data.rate);
+          setRateLoading(false);
+        }
       })
-    : "—";
+      .catch(() => {
+        if (!cancelled) {
+          setRateError(true);
+          setRateLoading(false);
+        }
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const rawXlm = xlmBalance ? parseFloat(xlmBalance.replace(/,/g, "")) : 0;
+  const mxnBalance = !xlmBalance
+    ? "—"
+    : rateLoading
+      ? "—"
+      : rateError
+        ? `~${(rawXlm * 20).toLocaleString("es-MX", { maximumFractionDigits: 2 })}`
+        : (rawXlm * (xlmMxnRate ?? 0)).toLocaleString("es-MX", { maximumFractionDigits: 2 });
 
   const today = new Date().toLocaleDateString("es-MX", {
     weekday: "long",

--- a/micopay/frontend/src/services/api.ts
+++ b/micopay/frontend/src/services/api.ts
@@ -295,6 +295,17 @@ export interface CETESTxResult {
   note?: string;
 }
 
+export interface XlmMxnRate {
+  rate: number;
+  source: string;
+  fetchedAt: string;
+}
+
+export async function getXlmMxnRate(): Promise<XlmMxnRate> {
+  const res = await http.get('/rate/xlm-mxn');
+  return res.data;
+}
+
 export async function getCETESRate(amount = "100"): Promise<CETESRate> {
   const res = await http.get(`/defi/cetes/rate?amount=${amount}`);
   return res.data;


### PR DESCRIPTION
Closes #161

---

Backend: new GET /rate/xlm-mxn endpoint fetching from CoinGecko (free, no API key). Returns 503 if upstream is unavailable.

Frontend: getXlmMxnRate() helper in api.ts. Home.tsx now fetches the real rate, shows '—' while loading, and prefixes with '~' on error.

Tests: Home.test.tsx extended with success and error scenarios.