### PR TITLE
docs(validation): add V-3 liquidity provider perspective

### DIFF
--- a/docs/VALIDATION_DRIPS.md
+++ b/docs/VALIDATION_DRIPS.md
@@ -93,7 +93,14 @@ _(no responses yet)_
 _(no responses yet)_
 
 ### V-3 · Liquidity provider perspective
-_(no responses yet)_
+
+- **Country / general region:** West Africa (Nigeria).
+- **Would YOU provide liquidity (give cash, receive digital balance)?:** Yes — with a few conditions in place first.
+- **Individual or small business?:** Individual. I run a small informal side-hustle alongside a day job; I regularly handle modest cash flows and already do occasional P2P exchanges for people in my circle.
+- **Main motivation:** Extra income from the commission, plus the convenience of converting digital balances I already hold (stablecoins) back into local currency without going through a bank. If neighbours come to me directly, it also builds goodwill and a small reputation locally.
+- **Perceived risks:** The biggest one for me is non-payment or a fake/reversed digital transfer — receiving what looks like a confirmation and then finding the funds were never real or got clawed back. A close second is physical safety: carrying or handing over cash in public can attract attention. I would also be cautious about regulatory ambiguity (is this treated as money-service activity in my jurisdiction?) and about disputes with no clear resolution path if something goes wrong.
+- **Commission I would expect:** 2–3%. Below 2% does not cover my time and liquidity risk; above 4% would probably push users back to informal channels and I would end up sitting idle.
+- **What would make me trust the system enough to try once:** Seeing the USDC locked in escrow *before* I hand over any cash — that single guarantee removes most of my risk. Beyond that: a verified transaction history for the counterparty, clear in-app instructions for each step, and a visible support/dispute path if something breaks. A successful first trade with a small amount would be enough to convince me to continue.
 
 ### V-4 · Non-custodial wallet onboarding
 _(no responses yet)_


### PR DESCRIPTION
Closes #133

Adds the `### V-3 · Liquidity provider perspective` section to `docs/VALIDATION_DRIPS.md`.

Covers all 7 required fields: region, willingness, individual/business type, motivation, perceived risks, expected commission %, and trust trigger. Privacy-safe — no real name, no cash amounts.