### PR TITLE
Add V-11 validation: transaction failure dispute and recovery context

### DIFF
--- a/docs/VALIDATION_DRIPS.md
+++ b/docs/VALIDATION_DRIPS.md
@@ -208,11 +208,11 @@ Aggregate signal:
 ### V-11 · Transaction failure: dispute and recovery context
 
 - **Country / general region:** Nigeria (West Africa)
-- **Q1 — What happened:** I was trying to transfer money from my local bank to an online bank so I could purchase something. The transfer failed at the very last stage — right after I entered the correct OTP verification code. Instead of completing, the transaction simply returned a failed error.
+- **Q1 — What happened:** I was trying to transfer money from my local bank to an online bank so I could purchase something. The transfer failed at the very last stage right after I entered the correct OTP verification code. Instead of completing, the transaction simply returned a failed error.
 - **Q2 — What I did next:** Since the transfer wouldn't go through, I had to find another way to get the money I needed. I reached out to my brother, who sent me cash to cover what I was trying to do instead of waiting on the bank.
 - **Q3 — Resolution and timeframe:** As of now, it's been over a week and the issue is still unresolved. I haven't been able to visit my bank's physical branch yet to report and resolve it, but I'm planning to if the error keeps happening.
-- **Q4 — What was missing:** Some way to immediately know what actually went wrong after entering the OTP — even a basic in-app explanation or status check — would have saved me from guessing. Easier access to support (without needing to physically visit a branch) would also make resolving this far less of a hassle.
-- **Q5 — How it changed my behavior:** I no longer have full confidence in my local bank's transfer system, since I now know it can fail at any point, even at the final OTP stage. That said, I haven't stopped using the bank entirely — I'm still trying it again and hoping things stabilize, since switching banks isn't simple either.
+- **Q4 — What was missing:** Some way to immediately know what actually went wrong after entering the OTP even a basic in-app explanation or status check would have saved me from guessing. Easier access to support (without needing to physically visit a branch) would also make resolving this far less of a hassle.
+- **Q5 — How it changed my behavior:** I no longer have full confidence in my local bank's transfer system, since I now know it can fail at any point, even at the final OTP stage. That said, I haven't stopped using the bank entirely I'm still trying it again and hoping things stabilize, since switching banks isn't simple either.
 
 ### V-12 · Market validation: living without a bank account — daily cash management
 

--- a/docs/VALIDATION_DRIPS.md
+++ b/docs/VALIDATION_DRIPS.md
@@ -205,6 +205,15 @@ Aggregate signal:
 - The main risk to repeat use is uncertainty around provider quality, availability, and support.
 - Recommendation is strongest when the experience feels safe, simple, and easy to explain to a friend.
 
+### V-11 · Transaction failure: dispute and recovery context
+
+- **Country / general region:** Nigeria (West Africa)
+- **Q1 — What happened:** I was trying to transfer money from my local bank to an online bank so I could purchase something. The transfer failed at the very last stage — right after I entered the correct OTP verification code. Instead of completing, the transaction simply returned a failed error.
+- **Q2 — What I did next:** Since the transfer wouldn't go through, I had to find another way to get the money I needed. I reached out to my brother, who sent me cash to cover what I was trying to do instead of waiting on the bank.
+- **Q3 — Resolution and timeframe:** As of now, it's been over a week and the issue is still unresolved. I haven't been able to visit my bank's physical branch yet to report and resolve it, but I'm planning to if the error keeps happening.
+- **Q4 — What was missing:** Some way to immediately know what actually went wrong after entering the OTP — even a basic in-app explanation or status check — would have saved me from guessing. Easier access to support (without needing to physically visit a branch) would also make resolving this far less of a hassle.
+- **Q5 — How it changed my behavior:** I no longer have full confidence in my local bank's transfer system, since I now know it can fail at any point, even at the final OTP stage. That said, I haven't stopped using the bank entirely — I'm still trying it again and hoping things stabilize, since switching banks isn't simple either.
+
 ### V-12 · Market validation: living without a bank account — daily cash management
 
 * **Country / general region:** Mexico (CDMX metropolitan area)


### PR DESCRIPTION
Closes #164 

## Summary
This PR adds the V-11 validation entry to docs/VALIDATION_DRIPS.md, sharing a first-person account of a failed bank transfer and the dispute/recovery experience that followed.

## What's included
- Country/region context (general region only, per privacy rules)
- What happened and where the transaction broke down
- What I did next to resolve the immediate need
- Current resolution status and timeframe
- What was missing that would have made recovery easier
- How the experience changed my behavior toward the service

## Privacy compliance
- No real names, phone numbers, addresses, wallet addresses, or transaction hashes
- No specific money amounts
- Only general country/region shared
- Entry reflects my own personal experience only