### PR TITLE
docs(wave6): sync research validation (V-11..V-14) into main

### DIFF
--- a/docs/AUDIT_APK_WAVE6.md
+++ b/docs/AUDIT_APK_WAVE6.md
@@ -108,17 +108,11 @@ es ahora deployable. Los P0 de frontend son el siguiente foco.
   el usuario actual). El endpoint `/account/balance` deja de usar `platformSecretKey` para la
   Home o se reemplaza por un endpoint explícito de saldo de usuario.
 
-### P0-4 · Fetch con ruta relativa roto dentro del APK
-- **Archivo:** `micopay/frontend/src/pages/Home.tsx:61-69`
-- **Qué pasa:** usa `fetch('/api/merchants/me/trades?state=pending')` con **ruta relativa**.
-  El resto de la app usa el cliente axios `http` con `baseURL = VITE_API_URL` (`api.ts:5-7`).
-  En el WebView de Capacitor, `/api/...` resuelve contra el origen de la app (`https://localhost`
-  / esquema de la app), no contra el backend.
-- **Por qué importa:** el badge de "operaciones pendientes" del comerciante **no carga en el
-  dispositivo** (funciona solo en web por el proxy de dev).
-- **Criterio de aceptación:** la llamada usa el helper de API con `baseURL` (p. ej.
-  `getMerchantTrades(token, 'pending')` ya existe en `api.ts:226-232`). Cero rutas relativas
-  `/api/...` en el código de pantallas.
+### ~~P0-4 · Fetch con ruta relativa roto dentro del APK~~ ✅ Resuelto
+- **Resuelto por:** [@josealfredo79](https://github.com/josealfredo79) · **Issue:** #150 · **PR:** #154 · **Mergeado:** 2026-06-25
+- ~~`fetch('/api/merchants/me/trades?state=pending')` con ruta relativa roto en Capacitor~~
+- **Fix:** reemplazado con `getMerchantTrades(merchantToken, 'pending')` del cliente axios. Se creó
+  `Home.test.tsx` desde cero con 5 casos cubriendo args correctos, token nulo, badge, estado vacío y error.
 
 ---
 
@@ -134,13 +128,11 @@ es ahora deployable. Los P0 de frontend son el siguiente foco.
   (`m.distance_km`, `m.payout_mxn`, `m.rate_percent`). `formatDistance`/`walkMinutes` (ya
   presentes en el archivo) se usan con la distancia real.
 
-### P1-2 · El mapa muestra pines inventados, no los comercios reales
-- **Archivo:** `micopay/frontend/src/components/MapSim.tsx:32-79`
-- **Qué pasa:** renderiza 3 pines fijos (Farmacia Guadalupe, @carlos_g, Centro Lavado) con
-  posiciones CSS hardcodeadas. No recibe ni grafica los comercios reales ni sus `lat/lng`.
-- **Criterio de aceptación:** el mapa grafica los comercios devueltos por `useMerchantsAvailable`
-  en su posición real (o, si se mantiene la simulación visual para el hackathon, etiquetarla
-  claramente como ilustrativa y no como ubicaciones reales).
+### ~~P1-2 · El mapa muestra pines inventados, no los comercios reales~~ ✅ Resuelto
+- **Resuelto por:** [@Gozirimdev](https://github.com/Gozirimdev) · **Issue:** #152 · **PR:** #156 · **Mergeado:** 2026-06-25
+- ~~3 pines fijos hardcodeados en `MapSim.tsx`~~
+- **Fix:** `getMerchantPins(merchants)` proyecta `lat/lng` reales de la API a posiciones CSS,
+  con clamp al rango 12–88% para mantenerlos dentro del viewport.
 
 ### P1-3 · Nombres de agente hardcodeados en el recibo
 - **Archivo:** `micopay/frontend/src/App.tsx:345`
@@ -148,21 +140,23 @@ es ahora deployable. Los P0 de frontend son el siguiente foco.
   El nombre real del comercio (disponible en `seller_username` vía `fetchTradeDetail`) no se usa.
 - **Criterio de aceptación:** el recibo muestra el `seller_username` real del trade.
 
-### P1-4 · Tipo de cambio XLM→MXN hardcodeado
-- **Archivo:** `micopay/frontend/src/pages/Home.tsx:71-76`
-- **Qué pasa:** `parseFloat(...) * 20` fijo ("demo rate"). No hay oráculo ni feed.
-- **Criterio de aceptación:** el tipo de cambio viene de una fuente del backend (endpoint de
-  rate / oráculo). Si no hay fuente aún, etiquetar el valor como aproximado/demo en la UI.
+### ~~P1-4 · Tipo de cambio XLM→MXN hardcodeado~~ ✅ Resuelto
+- **Resuelto por:** [@josealfredo79](https://github.com/josealfredo79) · **Issue:** #161 · **PR:** #162 · **Mergeado:** 2026-06-25
+- ~~`parseFloat(...) * 20` fijo ("demo rate")~~
+- **Fix:** nuevo `GET /rate/xlm-mxn` en `routes/rate.ts` llama a CoinGecko (free, sin API key,
+  timeout 5 s, 503 si upstream falla). Frontend usa `getXlmMxnRate()` con `useEffect` cancelable;
+  muestra `"—"` mientras carga y `~×20` con tilde si hay error.
+- ⚠️ **Follow-up pendiente (P2-4):** el endpoint no tiene caché — cada render de Home dispara
+  una llamada a CoinGecko. Ver §5 P2-4.
 
 ---
 
 ## 5. Hallazgos P2 — Endurecimiento de release
 
-### P2-1 · Sin gate de CI (riesgo de regresión)
-- **Hecho:** no existe `.github/workflows/`. La regresión previa (main sin compilar) ocurrió
-  justamente por mergear sin gate.
-- **Criterio de aceptación:** workflow que corra `tsc --noEmit` + `vite build` (y `vitest run`)
-  en cada PR a `main`, bloqueando merge si falla.
+### ~~P2-1 · Sin gate de CI (riesgo de regresión)~~ ✅ Resuelto
+- **Resuelto:** 2026-06-25 · `.github/workflows/ci.yml`
+- Corre `npm run build` en backend y `tsc + vite build` en frontend en cada PR a `main`.
+  `vitest` en modo informativo (`continue-on-error: true`) hasta que P0/P1 estabilicen los tests.
 
 ### P2-2 · DeFi (CETES / Blend) totalmente simulado
 - **Archivos:** `api.ts:285-374` (`simulated: boolean`), pantallas `CETESScreen.tsx`,
@@ -172,6 +166,15 @@ es ahora deployable. Los P0 de frontend son el siguiente foco.
   (`showDefi={!isDemoMode || !isMockStellar}` en `App.tsx:368-374`).
 - **Criterio de aceptación:** ningún flujo presenta una transacción simulada como real sin
   etiqueta visible.
+
+### P2-4 · `/rate/xlm-mxn` sin caché — riesgo de rate-limit CoinGecko
+- **Archivo:** `micopay/backend/src/routes/rate.ts`
+- **Qué pasa:** cada vez que `Home` monta hace una llamada directa a CoinGecko. El free tier
+  permite ~50 req/min por IP. Con varios usuarios simultáneos o recargas frecuentes, el servidor
+  puede quedar bloqueado y todos los usuarios verían el fallback `~×20` al mismo tiempo.
+- **Criterio de aceptación:** el endpoint guarda la última tasa en memoria con TTL de 60 s.
+  Si el TTL no expiró, responde el valor cacheado sin tocar CoinGecko. Si CoinGecko falla y
+  hay un valor previo en caché (aunque vencido), devolverlo con `stale: true` en lugar de 503.
 
 ### P2-3 · Configuración de release incompleta
 - **Push notifications:** `build.gradle:67-74` aplica `google-services` solo si existe
@@ -213,10 +216,11 @@ lo demás.
 | ~~P0-4~~ | ~~Fix fetch relativo en APK~~ | — | — | — | — | ✅ **Resuelto** — issue #150 cerrado, PR #154 mergeado |
 | P0-3 | Saldo real de la wallet del usuario | `wave:frontend`,`wave:backend` | `wave:retail` | medium | ✅ | Depende de P0-1 |
 | P0-5 | Onboarding mínimo: alias + respaldo de clave obligatorio (KYC Nivel 0) | `wave:frontend` | `wave:trust` | medium | ✅ | Sienta base para KYC por niveles (D-4) · pendiente pregunta 3 §9 |
-| ~~P1-1~~ | ~~ExploreMap usa economía real~~ | — | — | — | — | Issue #151 publicado (abierto, sin asignar) |
+| ~~P1-2~~ | ~~Mapa grafica comercios reales~~ | — | — | — | — | ✅ **Resuelto** — PR #156 · @Gozirimdev |
+| P1-1 | ExploreMap usa economía real | `wave:frontend` | `wave:retail` | medium | ✅ | Issue #151 publicado, abierto sin asignar |
 | P1-3 | Nombre real del agente en recibo | `wave:frontend` | `wave:retail` | low | ✅ | `ux` · depende de P0-2 (trade real) |
-| ~~P1-2~~ | ~~Mapa grafica comercios reales~~ | — | — | — | — | ✅ **Resuelto** — issue #152 cerrado, PR #156 mergeado |
-| P1-4 | Tipo de cambio XLM→MXN real | `wave:frontend`,`wave:backend` | `wave:retail` | medium | ✅ | Necesita endpoint de rate |
+| ~~P1-4~~ | ~~Tipo de cambio XLM→MXN real~~ | — | — | — | — | ✅ **Resuelto** — PR #162 · @josealfredo79 · follow-up: P2-4 caché |
+| P2-4 | Caché en-memoria para `/rate/xlm-mxn` | `wave:backend` | `wave:retail` | low | ✅ | Follow-up de P1-4 — ver §5 P2-4 |
 | B-3 | Desactivar fallback in-memory en prod | `wave:backend` | `wave:trust` | medium | — | **Interno** — `initPg()` aún silencioso; no publicar como Drips |
 | B-4 | No sembrar datos demo en prod | `wave:backend` | `wave:trust` | low | — | **Interno** — `seedData()` sin flag; no publicar como Drips |
 | B-7 | Health/readiness real (DB + config) | `wave:backend` | `wave:trust` | medium | — | **Interno** — `/health` parcial; no publicar como Drips |
@@ -248,30 +252,28 @@ lo demás.
 
 ### 6.3 Orden recomendado de publicar → asignar → mergear
 
-**Etapa 0 — Desbloqueo (interno, antes de abrir a contribuidores):**
-1. **B-1** backend build verde — sin esto nada se valida end-to-end.
-2. **P2-1** CI gate (frontend + backend) — protege todo merge posterior. Mergear apenas B-1 esté.
+**Etapa 0 — Desbloqueo (interno) ✅ COMPLETA:**
+1. ~~**B-1**~~ ✅ backend build verde.
+2. ~~**P2-1**~~ ✅ CI gate `.github/workflows/ci.yml`.
 
-**Etapa 1 — Núcleo "un usuario real, una transacción real" (P0):**
-3. **P0-1 + P0-2** (un solo PR/epic: identidad única + contraparte real). Decisiones D-1 y D-2 ya
-   cierran el alcance; resolver pregunta §9.3 (backup) antes de asignar P0-5.
-4. **P0-4** en paralelo (trivial, independiente).
-5. **P0-3** después de P0-1 (saldo por-usuario necesita identidad única).
-6. **P0-5** tras P0-1 (onboarding mínimo + respaldo de clave; KYC Nivel 0). Depende de §9.3.
+**Etapa 1 — Núcleo "un usuario real, una transacción real" (P0):** 🔄 En curso
+3. **P0-1 + P0-2** (issue #160, asignado en Drips) — en curso.
+4. ~~**P0-4**~~ ✅ PR #154 · @josealfredo79.
+5. **P0-3** — espera a que P0-1 aterrice.
+6. **P0-5** — espera resolución §9.3 (nivel de backup obligatorio).
 
-**Etapa 2 — "la UI deja de mentir" (P1, paralelizable entre contribuidores):**
-7. **P1-1** y **P1-2** (independientes, frontend puro).
-8. **P1-3** (tras P0-2) y **P1-4** (tras endpoint de rate).
+**Etapa 2 — "la UI deja de mentir" (P1):** 🔄 Parcialmente completa
+7. ~~**P1-2**~~ ✅ PR #156 · @Gozirimdev. **P1-1** (issue #151, abierto sin asignar).
+8. ~~**P1-4**~~ ✅ PR #162 · @josealfredo79. **P1-3** espera P0-2. **P2-4** (caché rate) listo para publicar.
 
-**Etapa 3 — Backend hardening (tras B-1, paralelizable):**
-9. **B-2, B-3, B-4, B-6, B-7**.
+**Etapa 3 — Backend hardening (interno):**
+9. **B-3, B-4, B-7** — trabajo interno pendiente. ~~B-2~~✅ ~~B-6~~✅
 
 **Etapa 4 — Decisiones de producto / release:**
-10. **P2-2** y **P2-3** (requieren decisión de producto primero).
+10. ~~**P2-2**~~ cerrado #86. ~~**P2-3**~~ cerrado #89.
 
-**Etapa paralela — Research (V-1…V-10, en cualquier momento):**
-- Las 10 de validación corren **en paralelo a todo** y ya están publicadas (milestone #18). Cada
-  asignado entrega por **PR** (su sección en `VALIDATION_DRIPS.md`). El label `research` ya existe.
+**Etapa paralela — Research (V-1…V-10):** 🔄 9/10 completas
+- ~~V-1~~✅ ~~V-2~~✅ **V-3** 🔴 sin PR. ~~V-4~~✅ ~~V-5~~✅ ~~V-6~~✅ ~~V-7~~✅ ~~V-8~~✅ ~~V-9~~✅ ~~V-10~~✅
 
 ### 6.4 Política de asignación y merge (de `DRIPS_TEAM_GUIDE.md`)
 
@@ -303,18 +305,18 @@ transacción. Las respuestas usan solo país/región general y relatos anonimiza
 
 ### Los 10 issues (publicados, milestone #18)
 
-| ID | Tema | Issue | Qué valida (SDF) |
-|----|------|-------|------------------|
-| V-1 | Cash-out | #131 | Demanda (digital → efectivo) |
-| V-2 | Cash-in / depósito | #132 | Demanda bidireccional |
-| V-3 | Proveedor de liquidez | #133 | Oferta |
-| V-4 | Onboarding no-custodial | #134 | Stellar self-custody usable |
-| V-5 | Confianza en el flujo | #135 | Confianza / PMF |
-| V-6 | Remesas | #138 | Demanda de remesas cross-border |
-| V-7 | Alternativas y switching | #139 | Diferenciación |
-| V-8 | Comisión justa | #140 | Economía unitaria (% sin montos) |
-| V-9 | Seguridad en persona | #141 | De-risk P2P |
-| V-10 | Recurrencia y descubrimiento | #142 | Retención / PMF |
+| ID | Tema | Issue | Qué valida (SDF) | Estado |
+|----|------|-------|------------------|--------|
+| V-1 | Cash-out | #131 | Demanda (digital → efectivo) | ✅ PR #155 · @larryjay007 |
+| V-2 | Cash-in / depósito | #132 | Demanda bidireccional | ✅ PR #159 · @Truphile (integrado manual) |
+| V-3 | Proveedor de liquidez | #133 | Oferta | 🔴 Sin PR — brecha crítica |
+| V-4 | Onboarding no-custodial | #134 | Stellar self-custody usable | ✅ PR #157 · @Shadow-MMN |
+| V-5 | Confianza en el flujo | #135 | Confianza / PMF | ✅ PR #158 · @Truphile (integrado manual) |
+| V-6 | Remesas | #138 | Demanda de remesas cross-border | ✅ PR #146 · @KaruG1999 |
+| V-7 | Alternativas y switching | #139 | Diferenciación | ✅ PR #145 · @barnabasolutayo-lgtm |
+| V-8 | Comisión justa | #140 | Economía unitaria (% sin montos) | ✅ PR #148 · @rosemary21 |
+| V-9 | Seguridad en persona | #141 | De-risk P2P | ✅ PR #147 · @deep-bhikadiya |
+| V-10 | Recurrencia y descubrimiento | #142 | Retención / PMF | ✅ PR #143 · @attyolu |
 
 Las preguntas completas (en primera persona) viven en cada issue.
 

--- a/docs/AUDIT_APK_WAVE6.md
+++ b/docs/AUDIT_APK_WAVE6.md
@@ -267,9 +267,9 @@ lo demás.
 **Etapa 4 — Decisiones de producto / release:**
 10. ~~**P2-2**~~ cerrado #86. ~~**P2-3**~~ cerrado #89.
 
-**Etapa paralela — Research (V-1…V-15):** 🔄 9/15 completas
-- ~~V-1~~✅ ~~V-2~~✅ **V-3**🔴 ~~V-4~~✅ ~~V-5~~✅ ~~V-6~~✅ ~~V-7~~✅ ~~V-8~~✅ ~~V-9~~✅ ~~V-10~~✅
-- V-11🆕 V-12🆕 V-13🆕 V-14🆕 V-15🆕 (publicados 2026-06-25, issues #164–#168)
+**Etapa paralela — Research (V-1…V-15):** 🔄 14/15 completas
+- ~~V-1~~✅ ~~V-2~~✅ ~~V-3~~✅ ~~V-4~~✅ ~~V-5~~✅ ~~V-6~~✅ ~~V-7~~✅ ~~V-8~~✅ ~~V-9~~✅ ~~V-10~~✅
+- ~~V-11~~✅ ~~V-12~~✅ ~~V-13~~✅ ~~V-14~~✅ **V-15**🔴 (único pendiente; issues #164–#168 publicados 2026-06-25)
 
 ### 6.4 Política de asignación y merge (de `DRIPS_TEAM_GUIDE.md`)
 
@@ -305,7 +305,7 @@ transacción. Las respuestas usan solo país/región general y relatos anonimiza
 |----|------|-------|------------------|--------|
 | V-1 | Cash-out | #131 | Demanda (digital → efectivo) | ✅ PR #155 · @larryjay007 |
 | V-2 | Cash-in / depósito | #132 | Demanda bidireccional | ✅ PR #159 · @Truphile |
-| V-3 | Proveedor de liquidez | #133 | Oferta | 🔴 Sin PR — brecha crítica |
+| V-3 | Proveedor de liquidez | #133 | Oferta | ✅ PR #169 · @DevSolex |
 | V-4 | Onboarding no-custodial | #134 | Stellar self-custody usable | ✅ PR #157 · @Shadow-MMN |
 | V-5 | Confianza en el flujo | #135 | Confianza / PMF | ✅ PR #158 · @Truphile |
 | V-6 | Remesas (receptor) | #138 | Demanda cross-border lado receptor | ✅ PR #146 · @KaruG1999 |
@@ -313,11 +313,11 @@ transacción. Las respuestas usan solo país/región general y relatos anonimiza
 | V-8 | Comisión justa | #140 | Economía unitaria (% sin montos) | ✅ PR #148 · @rosemary21 |
 | V-9 | Seguridad en persona | #141 | De-risk P2P | ✅ PR #147 · @deep-bhikadiya |
 | V-10 | Recurrencia y descubrimiento | #142 | Retención / PMF | ✅ PR #143 · @attyolu |
-| V-11 | Transacción fallida / disputa | #164 | Confianza — recuperación tras fallo | 🆕 Abierto |
-| V-12 | Vivir sin cuenta bancaria | #165 | Demanda — usuarios sin banco | 🆕 Abierto |
-| V-13 | Remesas (emisor) | #166 | Demanda + diferenciación lado emisor | 🆕 Abierto |
-| V-14 | Mental model peso digital / stablecoin | #167 | Capa stablecoin de Stellar | 🆕 Abierto |
-| V-15 | Umbral de primera vez | #168 | PMF — barrera de primera adopción | 🆕 Abierto |
+| V-11 | Transacción fallida / disputa | #164 | Confianza — recuperación tras fallo | ✅ Integrado PR #174 · @Chigybillionz |
+| V-12 | Vivir sin cuenta bancaria | #165 | Demanda — usuarios sin banco | ✅ PR #173 · @Oluwasuyi-Timilehin |
+| V-13 | Remesas (emisor) | #166 | Demanda + diferenciación lado emisor | ✅ Integrado PR #171 · @Jo-anny |
+| V-14 | Mental model peso digital / stablecoin | #167 | Capa stablecoin de Stellar | ✅ Integrado PR #175 · @Max-Owolabi |
+| V-15 | Umbral de primera vez | #168 | PMF — barrera de primera adopción | 🔴 Abierto — único pendiente |
 
 Las preguntas completas (en primera persona) viven en cada issue.
 

--- a/docs/AUDIT_APK_WAVE6.md
+++ b/docs/AUDIT_APK_WAVE6.md
@@ -167,14 +167,9 @@ es ahora deployable. Los P0 de frontend son el siguiente foco.
 - **Criterio de aceptación:** ningún flujo presenta una transacción simulada como real sin
   etiqueta visible.
 
-### P2-4 · `/rate/xlm-mxn` sin caché — riesgo de rate-limit CoinGecko
-- **Archivo:** `micopay/backend/src/routes/rate.ts`
-- **Qué pasa:** cada vez que `Home` monta hace una llamada directa a CoinGecko. El free tier
-  permite ~50 req/min por IP. Con varios usuarios simultáneos o recargas frecuentes, el servidor
-  puede quedar bloqueado y todos los usuarios verían el fallback `~×20` al mismo tiempo.
-- **Criterio de aceptación:** el endpoint guarda la última tasa en memoria con TTL de 60 s.
-  Si el TTL no expiró, responde el valor cacheado sin tocar CoinGecko. Si CoinGecko falla y
-  hay un valor previo en caché (aunque vencido), devolverlo con `stale: true` en lugar de 503.
+### ~~P2-4~~ · ~~`/rate/xlm-mxn` sin caché — riesgo de rate-limit CoinGecko~~ → ✅ **Resuelto 2026-06-26**
+- **Resuelto por:** [@josealfredo79](https://github.com/josealfredo79) · **PR:** [#172](https://github.com/ericmt-98/micopay-protocol/pull/172)
+- **Solución:** caché module-level con TTL de 60 s, fallback `stale: true` si CoinGecko falla con valor previo en caché, 503 solo si no hay caché. Tests en `rateCache.test.ts` (5 escenarios).
 
 ### P2-3 · Configuración de release incompleta
 - **Push notifications:** `build.gradle:67-74` aplica `google-services` solo si existe
@@ -220,7 +215,7 @@ lo demás.
 | P1-1 | ExploreMap usa economía real | `wave:frontend` | `wave:retail` | medium | ✅ | Issue #151 publicado, abierto sin asignar |
 | P1-3 | Nombre real del agente en recibo | `wave:frontend` | `wave:retail` | low | ✅ | `ux` · depende de P0-2 (trade real) |
 | ~~P1-4~~ | ~~Tipo de cambio XLM→MXN real~~ | — | — | — | — | ✅ **Resuelto** — PR #162 · @josealfredo79 · follow-up: P2-4 caché |
-| P2-4 | Caché en-memoria para `/rate/xlm-mxn` | `wave:backend` | `wave:retail` | low | ✅ | Follow-up de P1-4 — ver §5 P2-4 |
+| ~~P2-4~~ | ~~Caché en-memoria para `/rate/xlm-mxn`~~ | — | — | — | — | ✅ **Resuelto** — PR #172 · @josealfredo79 |
 | B-3 | Desactivar fallback in-memory en prod | `wave:backend` | `wave:trust` | medium | — | **Interno** — `initPg()` aún silencioso; no publicar como Drips |
 | B-4 | No sembrar datos demo en prod | `wave:backend` | `wave:trust` | low | — | **Interno** — `seedData()` sin flag; no publicar como Drips |
 | B-7 | Health/readiness real (DB + config) | `wave:backend` | `wave:trust` | medium | — | **Interno** — `/health` parcial; no publicar como Drips |
@@ -264,7 +259,7 @@ lo demás.
 
 **Etapa 2 — "la UI deja de mentir" (P1):** 🔄 Parcialmente completa
 7. ~~**P1-2**~~ ✅ PR #156 · @Gozirimdev. **P1-1** (issue #151, abierto sin asignar).
-8. ~~**P1-4**~~ ✅ PR #162 · @josealfredo79. **P1-3** espera P0-2. **P2-4** (caché rate) listo para publicar.
+8. ~~**P1-4**~~ ✅ PR #162 · @josealfredo79. **P1-3** espera P0-2. ~~**P2-4**~~ ✅ PR #172 · @josealfredo79.
 
 **Etapa 3 — Backend hardening (interno):**
 9. **B-3, B-4, B-7** — trabajo interno pendiente. ~~B-2~~✅ ~~B-6~~✅

--- a/docs/AUDIT_APK_WAVE6.md
+++ b/docs/AUDIT_APK_WAVE6.md
@@ -27,17 +27,18 @@ local no-custodial: crear keypair en la app o importar una clave secreta Stellar
 wallets externas móviles (LOBSTR, WalletConnect, etc.) quedan fuera del alcance inmediato; Freighter
 no debe asumirse como flujo principal para APK/iOS.
 
-**⚠️ Bloqueante #0 (verificado 2026-06-23):** aunque el frontend compila verde, el **backend
-`npm run build` falla** (errores TS en `index.ts`, `trade.service.ts`, `requestId.test.ts`, falta
-`firebase-admin`, props de config inexistentes). La app móvil habla con un backend que hoy **no es
-deployable**. Esto antecede a todos los P0 de frontend — ver B-1 en §6 y §8.
+**✅ Bloqueante #0 resuelto (2026-06-25):** `npm run build` en `micopay/backend` pasa limpio.
+CI gate en `.github/workflows/ci.yml` bloquea merges si backend o frontend rompen. El stack
+es ahora deployable. Los P0 de frontend son el siguiente foco.
 
 | Nivel | # | Tema |
 |------|---|------|
-| 🔴 B-1 | 1 | **Backend no compila** — bloqueante #0, precede a todo |
+| ~~🔴 B-1~~ | ~~1~~ | ~~**Backend no compila**~~ → ✅ **Resuelto 2026-06-25** |
+| ~~🟡 P2-1~~ | ~~1~~ | ~~**Sin CI gate**~~ → ✅ **Resuelto 2026-06-25** |
 | 🔴 P0 | 4 | Identidad doble, trade contra sí mismo, balance falso, fetch roto en APK |
 | 🟠 P1 | 4 | UI descarta datos reales (mapa, economía de oferta, nombres, tipo de cambio) |
-| 🟡 P2 | 3 | Sin CI gate, DeFi simulado, config de release |
+| 🟡 P2 | 2 | DeFi simulado, config de release (CI ya resuelto) |
+| ⚠️ B pendiente | 3 | B-3 (fallback in-memory), B-4 (seed en prod), B-7 (health real) — trabajo interno |
 
 ---
 
@@ -203,24 +204,24 @@ lo demás.
 
 | ID | Título corto | Superficie | Track | Complejidad | `Stellar Wave` | Notas |
 |----|--------------|-----------|-------|-------------|:---:|-------|
-| B-1 | Backend `npm run build` debe pasar | `wave:backend` | `wave:trust` | high | ✅ | **Bloqueante #0. Verificado: falla hoy.** |
-| P2-1 | CI gate: tsc + vite build + backend build | `wave:backend`,`wave:frontend` | `wave:docs` | medium | ✅ | Debe incluir el build del backend, no solo frontend |
-| P0-1 | Una sola identidad por dispositivo | `wave:frontend` | `wave:trust` | high | ✅ | Unir con P0-2 (mismo rediseño) · `wave:needs-product` |
+| ~~B-1~~ | ~~Backend `npm run build` debe pasar~~ | — | — | — | — | ✅ **Resuelto 2026-06-25** — build pasa limpio |
+| ~~P2-1~~ | ~~CI gate: tsc + vite build + backend build~~ | — | — | — | — | ✅ **Resuelto 2026-06-25** — `.github/workflows/ci.yml` |
+| ~~B-2~~ | ~~Config prod fail-fast si faltan secretos~~ | — | — | — | — | ✅ **Resuelto 2026-06-25** — `validateConfig()` lanza y crashea |
+| ~~B-6~~ | ~~Migraciones reproducibles + fix `init.sql`~~ | — | — | — | — | ✅ **Resuelto 2026-06-25** — `init.sql` eliminado, schema en código |
+| P0-1 | Una sola identidad por dispositivo | `wave:frontend` | `wave:trust` | high | ✅ | Unir con P0-2 (mismo rediseño) |
 | P0-2 | Trade contra contraparte real | `wave:frontend`,`wave:backend` | `wave:retail` | high | ✅ | Depende de P0-1 |
-| P0-4 | Fix fetch relativo en APK | `wave:frontend` | `wave:merchant` | low | ✅ | `bug` · independiente, merge cuando sea |
-| P0-3 | Saldo real de la wallet del usuario | `wave:frontend`,`wave:backend` | `wave:retail` | medium | ✅ | Depende de P0-1 · `wave:needs-product` |
-| P1-1 | ExploreMap usa economía real | `wave:frontend` | `wave:retail` | medium | ✅ | Independiente |
+| ~~P0-4~~ | ~~Fix fetch relativo en APK~~ | — | — | — | — | ✅ **Resuelto** — issue #150 cerrado, PR #154 mergeado |
+| P0-3 | Saldo real de la wallet del usuario | `wave:frontend`,`wave:backend` | `wave:retail` | medium | ✅ | Depende de P0-1 |
+| P0-5 | Onboarding mínimo: alias + respaldo de clave obligatorio (KYC Nivel 0) | `wave:frontend` | `wave:trust` | medium | ✅ | Sienta base para KYC por niveles (D-4) · pendiente pregunta 3 §9 |
+| ~~P1-1~~ | ~~ExploreMap usa economía real~~ | — | — | — | — | Issue #151 publicado (abierto, sin asignar) |
 | P1-3 | Nombre real del agente en recibo | `wave:frontend` | `wave:retail` | low | ✅ | `ux` · depende de P0-2 (trade real) |
-| P1-2 | Mapa grafica comercios reales | `wave:frontend` | `wave:retail` | medium | ✅ | `ux` · independiente |
+| ~~P1-2~~ | ~~Mapa grafica comercios reales~~ | — | — | — | — | ✅ **Resuelto** — issue #152 cerrado, PR #156 mergeado |
 | P1-4 | Tipo de cambio XLM→MXN real | `wave:frontend`,`wave:backend` | `wave:retail` | medium | ✅ | Necesita endpoint de rate |
-| B-2 | Config prod fail-fast si faltan secretos | `wave:backend` | `wave:trust` | medium | ✅ | Depende de B-1 |
-| B-3 | Desactivar fallback in-memory en prod | `wave:backend` | `wave:trust` | medium | ✅ | Depende de B-1 |
-| B-4 | No sembrar datos demo en prod | `wave:backend` | `wave:trust` | low | ✅ | Depende de B-1 |
-| B-6 | Migraciones reproducibles + fix `init.sql` (users duplicado, `audit_log` x2) | `wave:backend` | `wave:trust` | medium | ✅ | Depende de B-1 |
-| P0-5 | Onboarding mínimo: alias + respaldo de clave obligatorio (KYC Nivel 0) | `wave:frontend` | `wave:trust` | medium | ✅ | Sienta base para KYC por niveles (D-4) · `wave:needs-product` (pregunta 3) |
-| B-7 | Health/readiness real (DB + config) | `wave:backend` | `wave:trust` | medium | ✅ | Depende de B-1 |
-| P2-2 | Feature-gate o productizar DeFi | `wave:frontend`,`wave:backend` | `wave:retail` | medium | ✅ | `wave:needs-product` |
-| P2-3 | Config de release APK | `wave:frontend` | `wave:retail` | medium | ✅ | Push, firma, code-splitting |
+| B-3 | Desactivar fallback in-memory en prod | `wave:backend` | `wave:trust` | medium | — | **Interno** — `initPg()` aún silencioso; no publicar como Drips |
+| B-4 | No sembrar datos demo en prod | `wave:backend` | `wave:trust` | low | — | **Interno** — `seedData()` sin flag; no publicar como Drips |
+| B-7 | Health/readiness real (DB + config) | `wave:backend` | `wave:trust` | medium | — | **Interno** — `/health` parcial; no publicar como Drips |
+| ~~P2-2~~ | ~~Feature-gate o productizar DeFi~~ | — | — | — | — | Cerrado como issue #86 (wave anterior) |
+| ~~P2-3~~ | ~~Config de release APK~~ | — | — | — | — | Cerrado como issue #89 (wave anterior) |
 
 **Tratamiento especial:**
 - **B-5 (Dockerfile/guía de deploy)** → trabajo interno de maintainer/integrator. Roza Risk
@@ -335,55 +336,21 @@ datos personales ni detalles que identifiquen a participantes.
 
 ## 8. Backend readiness para servidor
 
-El backend tiene buen esqueleto para operar en servidor (`PORT`, `DATABASE_URL`, `/health`, logs,
-CORS para Capacitor y `listen` en `0.0.0.0`), pero **todavía no está listo para hostear como
-servicio real**. La verificación `cd micopay/backend && npm run build` falla actualmente con errores
-de TypeScript, por lo que el primer objetivo es volverlo deployable antes de exponerlo.
+> **Actualización 2026-06-25:** B-1 y P2-1 están resueltos (ver tabla abajo). B-5 se trata
+> internamente. B-3, B-4 y B-7 tienen trabajo pendiente puntual.
 
-### Issues iniciales sugeridos
+### Estado de los issues internos (verificado 2026-06-25)
 
-1. **Backend deploy blocker: `npm run build` debe pasar**
-   - Evidencia: `tsc` falla por imports faltantes en `src/index.ts`, config de event listener no
-     declarada, `sendTradeNotificationToMerchant` sin import, referencias a `query` sin definición
-     y un test con comparación literal inválida.
-   - Aceptación: `npm run build` pasa en `micopay/backend` sin errores TypeScript.
-
-2. **Backend production config: fallar fuerte si faltan secretos reales**
-   - Problema: `JWT_SECRET` cae a `dev_jwt_secret`; producción no debe arrancar con secretos demo.
-   - Aceptación: con `NODE_ENV=production`, el backend falla si faltan `DATABASE_URL`, `JWT_SECRET`,
-     `SECRET_ENCRYPTION_KEY` y las variables Stellar requeridas para el modo elegido.
-
-3. **Backend persistence: desactivar fallback in-memory en producción**
-   - Problema: `src/db/schema.ts` puede caer a almacenamiento en memoria si PostgreSQL no está
-     disponible. Eso es útil en demo/dev, pero peligroso en servidor real.
-   - Aceptación: en producción, si PostgreSQL no conecta, el proceso falla y `/health` no reporta
-     servicio sano. El fallback in-memory queda limitado a development/test.
-
-4. **Backend seed data: no sembrar datos demo en producción**
-   - Problema: `seedData()` inserta usuarios/trades demo al arrancar si no hay trades.
-   - Aceptación: el seed solo corre con flag explícito (`SEED_DEMO_DATA=true`) y nunca por default
-     en producción.
-
-5. **Backend deploy artifact: Dockerfile o guía de despliegue reproducible**
-   - Problema: no hay Dockerfile/compose/Procfile ni README operativo de despliegue.
-   - Aceptación: existe una ruta documentada para levantar el backend con Node + Postgres, variables
-     requeridas, build, start, health check y estrategia de logs.
-
-6. **Backend database schema/migrations reproducibles**
-   - Problema: no hay flujo claro de migraciones para crear/actualizar tablas en un servidor nuevo.
-     Además, **`sql/init.sql` está malformado**: la tabla `users` tiene columnas duplicadas/mezcladas
-     (dos bloques de definición pegados, líneas ~14–25) y el archivo **define `audit_log` dos veces**
-     con esquemas distintos (líneas ~32 y ~104). Un servidor nuevo no puede provisionar schema con
-     este archivo tal cual.
-   - Aceptación: un servidor vacío puede provisionar schema de forma reproducible antes de arrancar
-     la app, sin depender de estado local o inserts manuales. `sql/init.sql` corregido: `users` con
-     una sola definición coherente y `audit_log` declarada una sola vez (separar el audit de trades
-     del audit general si se necesitan ambos).
-
-7. **Backend health/readiness real**
-   - Problema: `/health` existe, pero debe distinguir proceso vivo vs servicio listo.
-   - Aceptación: health/readiness valida conexión a DB, configuración crítica y estado del listener
-     si está habilitado, sin exponer secretos.
+| ID | Título | Estado | Evidencia |
+|----|--------|--------|-----------|
+| **B-1** | Backend `npm run build` debe pasar | ✅ **Resuelto** | `cd micopay/backend && npm run build` → exit 0 sin errores TypeScript |
+| **P2-1** | CI gate: tsc + vite build + backend build | ✅ **Resuelto** | `.github/workflows/ci.yml` bloquea merge si backend o frontend no buildean; tests en modo informativo mientras P0/P1 se estabilizan |
+| **B-2** | Config prod fail-fast si faltan secretos | ✅ **Resuelto** | `validateConfig()` en `src/config.ts:92` lanza error y `start()` crashea via `process.exit(1)` si faltan `DATABASE_URL`, `SECRET_ENCRYPTION_KEY` o variables Stellar en modo real |
+| **B-6** | Migraciones / `init.sql` duplicado | ✅ **Resuelto** | `sql/init.sql` eliminado; schema vive en `src/db/schema.ts`; la tabla duplicada y el `audit_log` doble ya no existen |
+| **B-5** | Dockerfile / guía de deploy | — | Trabajo interno de maintainer; no se publica como issue Drips |
+| **B-3** | Desactivar fallback in-memory en prod | ⚠️ **Pendiente puntual** | `initPg()` corre a nivel de módulo y activa in-memory silenciosamente si Postgres falla. `validateConfig` solo verifica que `DATABASE_URL` no sea string vacío, no conectividad real. Criterio original: proceso falla si PG no conecta en producción |
+| **B-4** | No sembrar datos demo en producción | ⚠️ **Pendiente puntual** | `seedData()` en `src/index.ts:210` siembra sin flag explícito. Criterio original: seed solo corre con `SEED_DEMO_DATA=true` |
+| **B-7** | Health/readiness real | ⚠️ **Parcial** | `/health` expone `hasPlatformKey/hasDbUrl` (checks de string) y `eventListenerHealthy`, pero no verifica conectividad real al pool PG en cada request. Suficiente para demo; no suficiente como readiness probe de producción |
 
 ---
 

--- a/docs/AUDIT_APK_WAVE6.md
+++ b/docs/AUDIT_APK_WAVE6.md
@@ -272,8 +272,9 @@ lo demás.
 **Etapa 4 — Decisiones de producto / release:**
 10. ~~**P2-2**~~ cerrado #86. ~~**P2-3**~~ cerrado #89.
 
-**Etapa paralela — Research (V-1…V-10):** 🔄 9/10 completas
-- ~~V-1~~✅ ~~V-2~~✅ **V-3** 🔴 sin PR. ~~V-4~~✅ ~~V-5~~✅ ~~V-6~~✅ ~~V-7~~✅ ~~V-8~~✅ ~~V-9~~✅ ~~V-10~~✅
+**Etapa paralela — Research (V-1…V-15):** 🔄 9/15 completas
+- ~~V-1~~✅ ~~V-2~~✅ **V-3**🔴 ~~V-4~~✅ ~~V-5~~✅ ~~V-6~~✅ ~~V-7~~✅ ~~V-8~~✅ ~~V-9~~✅ ~~V-10~~✅
+- V-11🆕 V-12🆕 V-13🆕 V-14🆕 V-15🆕 (publicados 2026-06-25, issues #164–#168)
 
 ### 6.4 Política de asignación y merge (de `DRIPS_TEAM_GUIDE.md`)
 
@@ -308,15 +309,20 @@ transacción. Las respuestas usan solo país/región general y relatos anonimiza
 | ID | Tema | Issue | Qué valida (SDF) | Estado |
 |----|------|-------|------------------|--------|
 | V-1 | Cash-out | #131 | Demanda (digital → efectivo) | ✅ PR #155 · @larryjay007 |
-| V-2 | Cash-in / depósito | #132 | Demanda bidireccional | ✅ PR #159 · @Truphile (integrado manual) |
+| V-2 | Cash-in / depósito | #132 | Demanda bidireccional | ✅ PR #159 · @Truphile |
 | V-3 | Proveedor de liquidez | #133 | Oferta | 🔴 Sin PR — brecha crítica |
 | V-4 | Onboarding no-custodial | #134 | Stellar self-custody usable | ✅ PR #157 · @Shadow-MMN |
-| V-5 | Confianza en el flujo | #135 | Confianza / PMF | ✅ PR #158 · @Truphile (integrado manual) |
-| V-6 | Remesas | #138 | Demanda de remesas cross-border | ✅ PR #146 · @KaruG1999 |
+| V-5 | Confianza en el flujo | #135 | Confianza / PMF | ✅ PR #158 · @Truphile |
+| V-6 | Remesas (receptor) | #138 | Demanda cross-border lado receptor | ✅ PR #146 · @KaruG1999 |
 | V-7 | Alternativas y switching | #139 | Diferenciación | ✅ PR #145 · @barnabasolutayo-lgtm |
 | V-8 | Comisión justa | #140 | Economía unitaria (% sin montos) | ✅ PR #148 · @rosemary21 |
 | V-9 | Seguridad en persona | #141 | De-risk P2P | ✅ PR #147 · @deep-bhikadiya |
 | V-10 | Recurrencia y descubrimiento | #142 | Retención / PMF | ✅ PR #143 · @attyolu |
+| V-11 | Transacción fallida / disputa | #164 | Confianza — recuperación tras fallo | 🆕 Abierto |
+| V-12 | Vivir sin cuenta bancaria | #165 | Demanda — usuarios sin banco | 🆕 Abierto |
+| V-13 | Remesas (emisor) | #166 | Demanda + diferenciación lado emisor | 🆕 Abierto |
+| V-14 | Mental model peso digital / stablecoin | #167 | Capa stablecoin de Stellar | 🆕 Abierto |
+| V-15 | Umbral de primera vez | #168 | PMF — barrera de primera adopción | 🆕 Abierto |
 
 Las preguntas completas (en primera persona) viven en cada issue.
 

--- a/docs/VALIDATION_DRIPS.md
+++ b/docs/VALIDATION_DRIPS.md
@@ -86,8 +86,13 @@ Fill these in as answers arrive. Keep counts and percentages only.
 
 ## Aggregate findings (one `### V-X` section per contributor PR)
 
-### V-1 · Cash-out context
-_(no responses yet)_
+### V-1 · Cash-out 
+* Country / Region: Nigeria (South West)
+* Cash-out frequency: Weekly
+* Current method: Peer-to-peer exchange or bank transfer to a local bank account, followed by ATM withdrawal or cash-out through a POS agent.
+* Main friction: High cumulative transaction fees, unreliable ATM availability, and daily withdrawal limits.
+* Personal experience: I frequently receive digital funds and need physical cash for everyday expenses such as transportation and purchases at local markets. One recent experience was particularly frustrating, I spent more than an hour moving between three different bank locations because the first two had either empty ATMs or network issues. When I finally found a working ATM, the withdrawal limit was so low that I had to make multiple transactions, resulting in additional bank charges.
+
 
 ### V-2 · Cash-in / deposit context
 _(no responses yet)_

--- a/docs/VALIDATION_DRIPS.md
+++ b/docs/VALIDATION_DRIPS.md
@@ -235,7 +235,14 @@ Aggregate signal:
 - Recommendation is strongest when the experience feels safe, simple, and easy to explain to a friend.
 
 ### V-11 · Failed transaction / dispute handling
-_(no responses yet)_
+**Contributor:** [@Chigybillionz](https://github.com/Chigybillionz) · **PR:** [#174](https://github.com/ericmt-98/micopay-protocol/pull/174)
+
+- **Country / general region:** Nigeria (West Africa)
+- **What happened:** Tried to transfer money from a local bank to an online bank to make a purchase. The transfer failed at the very last stage, right after entering the correct OTP verification code — it just returned a failed error instead of completing.
+- **What I did next:** Since the transfer wouldn't go through, I had to find another way. I reached out to my brother, who sent me cash to cover what I was trying to do instead of waiting on the bank.
+- **Resolution and timeframe:** Over a week later, still unresolved. I haven't been able to visit the bank's physical branch to report it, but I plan to if the error keeps happening.
+- **What was missing:** Some way to immediately know what actually went wrong after entering the OTP — even a basic in-app explanation or status check would have saved me from guessing. Easier access to support without physically visiting a branch would also make resolving this far less of a hassle.
+- **How it changed my behavior:** I no longer have full confidence in my local bank's transfer system, since it can fail at any point, even at the final OTP stage. I haven't stopped using the bank entirely — switching banks isn't simple either — but the trust is dented.
 
 ### V-12 · Living unbanked — everyday context
 **Contributor:** [@Oluwasuyi-Timilehin](https://github.com/Oluwasuyi-Timilehin) · **PR:** [#173](https://github.com/ericmt-98/micopay-protocol/pull/173)
@@ -259,7 +266,7 @@ _(no responses yet)_
 - **What would make me switch?:** A cheaper, faster, and more transparent service with a reliable, immediate local cash-out path. The one thing that would have to be better is certainty: knowing the final amount received and the cash-out option before I send.
 
 ### V-14 · Stablecoin / digital peso mental model
-**Contributor:** [@Max-Owolabi](https://github.com/Max-Owolabi) · **PR:** [#170](https://github.com/ericmt-98/micopay-protocol/pull/170)
+**Contributor:** [@Max-Owolabi](https://github.com/Max-Owolabi) · **PR:** [#175](https://github.com/ericmt-98/micopay-protocol/pull/175)
 
 - **Country / general region:** Nigeria (West Africa)
 - **Have you ever held or used a digital stablecoin?:** Yes. I have held and used USDC and USDT on Stellar and other networks. I obtained them by purchasing through local exchange agents or peer-to-peer (P2P) platforms, and I used them to preserve value against local currency inflation and to pay for digital services online where local cards fail.

--- a/docs/VALIDATION_DRIPS.md
+++ b/docs/VALIDATION_DRIPS.md
@@ -86,24 +86,38 @@ Fill these in as answers arrive. Keep counts and percentages only.
 
 ## Aggregate findings (one `### V-X` section per contributor PR)
 
-### V-1 · Cash-out 
-* Country / Region: Nigeria (South West)
-* Cash-out frequency: Weekly
-* Current method: Peer-to-peer exchange or bank transfer to a local bank account, followed by ATM withdrawal or cash-out through a POS agent.
-* Main friction: High cumulative transaction fees, unreliable ATM availability, and daily withdrawal limits.
-* Personal experience: I frequently receive digital funds and need physical cash for everyday expenses such as transportation and purchases at local markets. One recent experience was particularly frustrating, I spent more than an hour moving between three different bank locations because the first two had either empty ATMs or network issues. When I finally found a working ATM, the withdrawal limit was so low that I had to make multiple transactions, resulting in additional bank charges.
+### V-1 · Cash-out context
+**Contributor:** [@larryjay007](https://github.com/larryjay007) · **PR:** [#155](https://github.com/ericmt-98/micopay-protocol/pull/155) · **Region:** Nigeria (South West)
+
+First-person response (privacy-safe):
+
+- **Country / region:** Nigeria (South West)
+- **Cash-out frequency:** Weekly
+- **Current method:** Peer-to-peer exchange or bank transfer to a local bank account, followed by ATM withdrawal or cash-out through a POS agent.
+- **Main friction:** High cumulative transaction fees, unreliable ATM availability, and daily withdrawal limits.
+- **Personal experience:** I frequently receive digital funds and need physical cash for everyday expenses such as transportation and purchases at local markets. One recent experience was particularly frustrating — I spent more than an hour moving between three different bank locations because the first two had either empty ATMs or network issues. When I finally found a working ATM, the withdrawal limit was so low that I had to make multiple transactions, resulting in additional bank charges.
+
+**SDF narrative:** Adds Nigeria (South West) to the cash-out demand signal for Claim 1. Weekly frequency + ATM reliability failures + daily withdrawal limits combine into a strong recurring pain that a local P2P agent network directly addresses.
 
 ### V-2 · Cash-in / deposit context
+**Contributor:** [@Truphile](https://github.com/Truphile) · **PR:** [#159](https://github.com/ericmt-98/micopay-protocol/pull/159) · **Region:** Nigeria (West Africa)
 
-_(no responses yet)_
+First-person response (privacy-safe):
+
+- **Why I'd use cash-in:** Getting paper money out of my hands and into my phone where it's actually useful. If I collect cash from a friend or an offline gig, I can't use that paper to pay for AWS bills, local utility tokens, or fund a fintech savings pocket. I need a quick way to drop the cash and see it hit my digital wallet instantly.
+- **Current method:** I walk up to a nearby neighborhood PoS agent. I hand them the physical cash, give them my account details, and wait for them to do a transfer to my wallet on their terminal.
+- **Frequency:** A few times a month — whenever paper cash piles up, I need to clear it out.
+- **Trust barrier:** Network issues, hands down. The fear of handing over cold hard cash and then hearing the agent say "Network is bad, the money hasn't dropped yet." If the system crashes mid-operation, you're stuck arguing at a kiosk, waiting for a network reversal that could take 24–48 hours.
+- **Local trusted providers:** Yes. There are established, branded kiosks and shops right on my street that have been there for years. Everyone in the area uses them, and because they are tied to a permanent physical location, they can't afford to ruin their reputation over a bad transaction.
+
+**SDF narrative:** Confirms bidirectional demand (Claim 1) from West Africa — a user who actively needs to digitize physical cash and already trusts local PoS agents. The main risk to address is mid-operation network failure and confirmation latency.
 
 ### V-3 · Liquidity provider perspective
 
 _(no responses yet)_
 
 ### V-4 · Non-custodial wallet onboarding
-
-**Contributor:** Shadow-MMN
+**Contributor:** [@Shadow-MMN](https://github.com/Shadow-MMN) · **PR:** [#157](https://github.com/ericmt-98/micopay-protocol/pull/157) · **Region:** —
 
 - **Is it clear to YOU that you hold the key and must back it up?:** Not clear at all. There is no onboarding screen or maybe I am missing something but the keypair was generated (I found out by checking the brower's localStorage).
 - **Your biggest doubt or fear about a non-custodial wallet:** Losing the key to a hacker since it is stored on my localStorage.
@@ -112,69 +126,22 @@ _(no responses yet)_
 - **In your view, should backing up the key be mandatory at sign-up, or optional? (and why):** Optional, but the UI should make it trivially easy i.e a single tap to copy the key, accompanied by a visible note telling the user to save the copied text somewhere safe and never share it. Making it mandatory would frustrate users who just want to try the app, but the option should be prominent enough that nobody misses it.
 
 ### V-5 · Trust in the cash-in/cash-out flow
+**Contributor:** [@Truphile](https://github.com/Truphile) · **PR:** [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) · **Region:** Nigeria (West Africa)
 
-_(no responses yet)_
+First-person response (privacy-safe):
+
+- **Most trusted provider type:** A well-established, branded neighborhood PoS agent with a permanent physical kiosk and a steady stream of daily customers. Seeing them use a dedicated, functional Android PoS terminal instantly builds confidence.
+- **Least trusted:** A mobile, unbranded agent sitting casually on the street corner with just a phone, or an untrusted shop owner who claims "network is bad" before even attempting the transaction.
+- **Minimum info before handing over cash:** The exact commission fee clearly stated upfront · the final locked-in value that will reflect in the wallet · a clear confirmation on the agent's screen showing the system is active and online.
+- **Verification signals for providers:** The agent's location and banner name matching exactly what is displayed on the in-app map · a verified merchant status indicator showing a high completion rate or a "Trusted Agent" badge.
+- **Support expectations mid-failure:** An immediate, automated SMS receipt or in-app "Pending / Money Received" status to prove the transaction is in flight · a clear WhatsApp support channel or toll-free line to resolve hanging transactions within minutes.
+- **Top reason to abandon:** "Network Issues" and delay — if the agent says "network is fluctuating" or the app takes too long to generate the QR code/receipt. Any delay at point of payment triggers a fear of trapped funds.
+
+**SDF narrative:** Directly maps the trust and abandonment signals for Claim 5 (Trust / PMF). The three-part "minimum info before handing over cash" is a concrete UX checklist — transparent fee, locked rate, online status — that the agent flow must display before cash changes hands.
 
 ### V-6 · Remittances cash-out context
 **Contributor:** [@KaruG1999](https://github.com/KaruG1999) · **PR:** [#146](https://github.com/ericmt-98/micopay-protocol/pull/146) · **Region:** Argentina (LATAM)
 
-<<<<<<< HEAD
-=======
-- **Country / general region:** Argentina (LATAM)
-- **Do YOU receive money from abroad?:** Yes
-- **How do you receive it today?:** Crypto (Stablecoins via Stellar/Soroban protocols and P2P networks) and global digital platforms.
-- **Your main friction receiving + cashing it out:** Fee and trust. Standard international banking wires trigger excessive regulatory friction, high baseline inbound fees, and unfavorable official currency conversion rates. While crypto solves cross-border speed, cashing out stablecoins to local fiat (ARS) still relies heavily on localized P2P order books or physical over-the-counter (OTC) exchanges, introducing variable spread fees and counterparty trust risks.
-- **Would getting it as cash nearby, same day, help YOU?:** Yes. Eliminating the P2P counterparty matching phase and having an immediate, compliant, same-day physical cash-out point nearby would drastically reduce transactional friction and eliminate exchange-rate slippage.
-
-### V-7 · Current alternatives & switching
-
-Small anonymized sample (N=4; self + 3 peers, convenience sample across Mexico and other Latin American regions):
-
-- Respondent A — Monterrey region, Mexico
-  - What they use today: OXXO stores and traditional bank ATMs.
-  - What they like: High availability and the security of established, well-known brands.
-  - What frustrates them: High transaction/convenience fees, long wait lines, and occasional ATM outages.
-  - What would make them switch: Lower fees, zero queue times, and local neighborhood exchange points.
-  - Dealbreaker: Upfront payment/fees before receiving cash, or overly complex apps that require advanced crypto/technical knowledge.
-
-- Respondent B — Bogotá area, Colombia
-  - What they use today: Mobile wallets (Nequi, Daviplata) and physical lottery kiosks (Efecty, Paga Todo) for cash-out.
-  - What they like: Instant digital transfers and wide physical availability of cash points.
-  - What frustrates them: Frequent app system outages, daily transaction limits, and high agent commissions.
-  - What would make them switch: A highly reliable system working 24/7 with transparent, lower fees and flexible limits.
-  - Dealbreaker: Lack of immediate transaction confirmation or lack of support channels to resolve stuck operations.
-
-- Respondent C — Buenos Aires, Argentina
-  - What they use today: Local informal exchange houses ("cuevas") and P2P crypto exchanges (Binance P2P).
-  - What they like: Inflation hedging by holding stablecoins (USDT) and converting to fiat cash as needed.
-  - What frustrates them: Safety risks of carrying physical cash from physical exchanges, and counterparty trust issues in online P2P.
-  - What would make them switch: A secure, trust-rated network of local merchants/providers for safe, local stablecoin-to-cash exchange.
-  - Dealbreaker: High platform service fees or mandatory KYC that requires multi-day validation for tiny transactions.
-
-- Respondent D — Caracas metropolitan area, Venezuela
-  - What they use today: Binance P2P, Pago Móvil bank transfers, and informal USD cash transactions.
-  - What they like: Fast digital payments (Pago Móvil) and holding USD-linked assets.
-  - What frustrates them: Scarcity of physical USD/local fiat cash and high exchange/broker fees (often >5%).
-  - What would make them switch: Direct connection to nearby verified cash providers at low transaction fees (<2%) with instant escrow settlement.
-  - Dealbreaker: High rate of transaction failures or lack of secure escrows to prevent loss/theft of digital assets during cash exchanges.
-
-Aggregate signal:
-
-- **Current alternatives:** Users rely heavily on established retail/agent networks (OXXO, Efecty), mobile wallets, and crypto P2P platforms (Binance) depending on the country's economic context.
-- **Key switching drivers:** Lower transaction fees, zero queues, higher system uptime (avoiding wallet outages), and safer/more localized physical exchange points.
-- **Key dealbreakers:** Escrow/security concerns (fear of losing funds), high entry friction (e.g. upfront payments or heavy KYC for small amounts), and poor app usability/technical complexity.
-
-### V-8 · Fair commission / fee tolerance
-
-- **Country / region:** Lagos area, Nigeria.
-- **Fair commission for cashing out:** 1–3% feels reasonable to me — enough to compensate a provider for their time and liquidity risk, but low enough that the convenience is still worth it over walking to a bank or agent.
-- **Too-high threshold:** Anything above 5% and I would rather deal with the friction of a traditional channel. At that point the fee starts to feel exploitative rather than a fair service charge.
-- **What would justify a higher fee:** Not having to use a bank account at all is the biggest one for me — that alone unlocks access. Speed (same-day settlement) and a clear safety guarantee (verified provider, in-app dispute path) would also make me willing to stretch a little above my usual ceiling.
-- **Would I pay more for a closer / faster provider:** Yes. If the alternative is travelling further or waiting longer, a small premium for proximity and speed is worth it.
-
-### V-9 · Safety meeting in person
-
->>>>>>> a84be11 (V-4: add non-custodial wallet onboarding response)
 First-person response (privacy-safe):
 
 - Do I receive money from abroad? Yes — via stablecoins on Stellar/Soroban and P2P networks.

--- a/docs/VALIDATION_DRIPS.md
+++ b/docs/VALIDATION_DRIPS.md
@@ -27,13 +27,13 @@ reviews each PR for privacy before merging.
 A funding/grant case for MicoPay on Stellar rests on a few claims. The research issues each
 supply evidence for one of them:
 
-| Claim | Backed by | One-line thesis |
-|---|---|---|
-| **1. Demand exists** | V-1 (cash-out), V-2 (cash-in), V-6 (remittances) | A real, recurring pain converting digital ↔ cash |
-| **2. Supply exists** | V-3 (liquidity providers) | Real people/businesses would provide cash for a commission |
-| **3. It can win** | V-7 (alternatives), V-8 (fair fee) | Better than current options, at a fee users accept |
-| **4. Stellar is usable** | V-4 (non-custodial onboarding) | Mainstream users can handle a self-custodial wallet |
-| **5. Trust / PMF** | V-5 (flow trust), V-9 (safety), V-10 (repeat use) | Users would adopt, feel safe, and come back |
+| Claim                    | Backed by                                         | One-line thesis                                            |
+| ------------------------ | ------------------------------------------------- | ---------------------------------------------------------- |
+| **1. Demand exists**     | V-1 (cash-out), V-2 (cash-in), V-6 (remittances)  | A real, recurring pain converting digital ↔ cash           |
+| **2. Supply exists**     | V-3 (liquidity providers)                         | Real people/businesses would provide cash for a commission |
+| **3. It can win**        | V-7 (alternatives), V-8 (fair fee)                | Better than current options, at a fee users accept         |
+| **4. Stellar is usable** | V-4 (non-custodial onboarding)                    | Mainstream users can handle a self-custodial wallet        |
+| **5. Trust / PMF**       | V-5 (flow trust), V-9 (safety), V-10 (repeat use) | Users would adopt, feel safe, and come back                |
 
 > Put together: **demand + supply + a winning, affordable, usable, trusted experience = a
 > credible case that a Stellar P2P cash network serves the financially underserved.**
@@ -42,8 +42,8 @@ supply evidence for one of them:
 
 ## Macro context (TAM — from public data, not from this survey)
 
-The *size* of the problem comes from public sources; cite them in the deck. The survey adds
-*willingness and trust*, which public data can't give. Approximate figures to verify and cite:
+The _size_ of the problem comes from public sources; cite them in the deck. The survey adds
+_willingness and trust_, which public data can't give. Approximate figures to verify and cite:
 
 - Remittances to Mexico: ~US$60B+/year (cite World Bank / Banxico, latest year).
 - Share of population unbanked / underbanked in Mexico: majority (cite ENIF / World Bank Findex).
@@ -58,19 +58,19 @@ The *size* of the problem comes from public sources; cite them in the deck. The 
 
 Fill these in as answers arrive. Keep counts and percentages only.
 
-| Metric | From | Target signal |
-|---|---|---|
-| % reporting cash-out as a recurring need · top friction | V-1 | demand |
-| % with a real cash-in use case · main trust barrier | V-2 | bidirectional demand |
-| % willing to provide liquidity · acceptable commission (%) | V-3 | supply / unit economics |
-| % who find non-custodial backup clear (vs confusing) | V-4 | onboarding viability |
-| Top trust blocker · top reason to abandon | V-5 | PMF / drop-off risk |
-| % who receive remittances · would same-day local cash help | V-6 | remittance demand |
-| What they use today · top switch trigger · dealbreaker | V-7 | differentiation |
-| Fair commission % (distribution) · "too high" threshold | V-8 | unit economics |
-| Comfort meeting a stranger · top safety fear · shops vs individuals | V-9 | safety / de-risking |
-| Discovery method · repeat-use (yes/maybe/no) · recommend driver | V-10 | retention / PMF |
-| Regions represented (count by region) · total respondents (N) | all | spread / sample size |
+| Metric                                                              | From | Target signal           |
+| ------------------------------------------------------------------- | ---- | ----------------------- |
+| % reporting cash-out as a recurring need · top friction             | V-1  | demand                  |
+| % with a real cash-in use case · main trust barrier                 | V-2  | bidirectional demand    |
+| % willing to provide liquidity · acceptable commission (%)          | V-3  | supply / unit economics |
+| % who find non-custodial backup clear (vs confusing)                | V-4  | onboarding viability    |
+| Top trust blocker · top reason to abandon                           | V-5  | PMF / drop-off risk     |
+| % who receive remittances · would same-day local cash help          | V-6  | remittance demand       |
+| What they use today · top switch trigger · dealbreaker              | V-7  | differentiation         |
+| Fair commission % (distribution) · "too high" threshold             | V-8  | unit economics          |
+| Comfort meeting a stranger · top safety fear · shops vs individuals | V-9  | safety / de-risking     |
+| Discovery method · repeat-use (yes/maybe/no) · recommend driver     | V-10 | retention / PMF         |
+| Regions represented (count by region) · total respondents (N)       | all  | spread / sample size    |
 
 ---
 
@@ -93,22 +93,88 @@ Fill these in as answers arrive. Keep counts and percentages only.
 * Main friction: High cumulative transaction fees, unreliable ATM availability, and daily withdrawal limits.
 * Personal experience: I frequently receive digital funds and need physical cash for everyday expenses such as transportation and purchases at local markets. One recent experience was particularly frustrating, I spent more than an hour moving between three different bank locations because the first two had either empty ATMs or network issues. When I finally found a working ATM, the withdrawal limit was so low that I had to make multiple transactions, resulting in additional bank charges.
 
-
 ### V-2 · Cash-in / deposit context
+
 _(no responses yet)_
 
 ### V-3 · Liquidity provider perspective
+
 _(no responses yet)_
 
 ### V-4 · Non-custodial wallet onboarding
-_(no responses yet)_
+
+**Contributor:** Shadow-MMN
+
+- **Is it clear to YOU that you hold the key and must back it up?:** Not clear at all. There is no onboarding screen or maybe I am missing something but the keypair was generated (I found out by checking the brower's localStorage).
+- **Your biggest doubt or fear about a non-custodial wallet:** Losing the key to a hacker since it is stored on my localStorage.
+- **What would make YOU trust this onboarding:** I would not trust it in its current form because there is no onboarding at all. A dedicated screen at first launch explaining that a wallet was created and showing the public key, with a clear call to back up the secret key, would be the minimum.
+- **Your preference: create a new wallet vs import an existing Stellar key (and why):** Import an existing wallet key. I already have a wallet with funds and do not want the hassle of moving money between wallets.
+- **In your view, should backing up the key be mandatory at sign-up, or optional? (and why):** Optional, but the UI should make it trivially easy i.e a single tap to copy the key, accompanied by a visible note telling the user to save the copied text somewhere safe and never share it. Making it mandatory would frustrate users who just want to try the app, but the option should be prominent enough that nobody misses it.
 
 ### V-5 · Trust in the cash-in/cash-out flow
+
 _(no responses yet)_
 
 ### V-6 · Remittances cash-out context
 **Contributor:** [@KaruG1999](https://github.com/KaruG1999) · **PR:** [#146](https://github.com/ericmt-98/micopay-protocol/pull/146) · **Region:** Argentina (LATAM)
 
+<<<<<<< HEAD
+=======
+- **Country / general region:** Argentina (LATAM)
+- **Do YOU receive money from abroad?:** Yes
+- **How do you receive it today?:** Crypto (Stablecoins via Stellar/Soroban protocols and P2P networks) and global digital platforms.
+- **Your main friction receiving + cashing it out:** Fee and trust. Standard international banking wires trigger excessive regulatory friction, high baseline inbound fees, and unfavorable official currency conversion rates. While crypto solves cross-border speed, cashing out stablecoins to local fiat (ARS) still relies heavily on localized P2P order books or physical over-the-counter (OTC) exchanges, introducing variable spread fees and counterparty trust risks.
+- **Would getting it as cash nearby, same day, help YOU?:** Yes. Eliminating the P2P counterparty matching phase and having an immediate, compliant, same-day physical cash-out point nearby would drastically reduce transactional friction and eliminate exchange-rate slippage.
+
+### V-7 · Current alternatives & switching
+
+Small anonymized sample (N=4; self + 3 peers, convenience sample across Mexico and other Latin American regions):
+
+- Respondent A — Monterrey region, Mexico
+  - What they use today: OXXO stores and traditional bank ATMs.
+  - What they like: High availability and the security of established, well-known brands.
+  - What frustrates them: High transaction/convenience fees, long wait lines, and occasional ATM outages.
+  - What would make them switch: Lower fees, zero queue times, and local neighborhood exchange points.
+  - Dealbreaker: Upfront payment/fees before receiving cash, or overly complex apps that require advanced crypto/technical knowledge.
+
+- Respondent B — Bogotá area, Colombia
+  - What they use today: Mobile wallets (Nequi, Daviplata) and physical lottery kiosks (Efecty, Paga Todo) for cash-out.
+  - What they like: Instant digital transfers and wide physical availability of cash points.
+  - What frustrates them: Frequent app system outages, daily transaction limits, and high agent commissions.
+  - What would make them switch: A highly reliable system working 24/7 with transparent, lower fees and flexible limits.
+  - Dealbreaker: Lack of immediate transaction confirmation or lack of support channels to resolve stuck operations.
+
+- Respondent C — Buenos Aires, Argentina
+  - What they use today: Local informal exchange houses ("cuevas") and P2P crypto exchanges (Binance P2P).
+  - What they like: Inflation hedging by holding stablecoins (USDT) and converting to fiat cash as needed.
+  - What frustrates them: Safety risks of carrying physical cash from physical exchanges, and counterparty trust issues in online P2P.
+  - What would make them switch: A secure, trust-rated network of local merchants/providers for safe, local stablecoin-to-cash exchange.
+  - Dealbreaker: High platform service fees or mandatory KYC that requires multi-day validation for tiny transactions.
+
+- Respondent D — Caracas metropolitan area, Venezuela
+  - What they use today: Binance P2P, Pago Móvil bank transfers, and informal USD cash transactions.
+  - What they like: Fast digital payments (Pago Móvil) and holding USD-linked assets.
+  - What frustrates them: Scarcity of physical USD/local fiat cash and high exchange/broker fees (often >5%).
+  - What would make them switch: Direct connection to nearby verified cash providers at low transaction fees (<2%) with instant escrow settlement.
+  - Dealbreaker: High rate of transaction failures or lack of secure escrows to prevent loss/theft of digital assets during cash exchanges.
+
+Aggregate signal:
+
+- **Current alternatives:** Users rely heavily on established retail/agent networks (OXXO, Efecty), mobile wallets, and crypto P2P platforms (Binance) depending on the country's economic context.
+- **Key switching drivers:** Lower transaction fees, zero queues, higher system uptime (avoiding wallet outages), and safer/more localized physical exchange points.
+- **Key dealbreakers:** Escrow/security concerns (fear of losing funds), high entry friction (e.g. upfront payments or heavy KYC for small amounts), and poor app usability/technical complexity.
+
+### V-8 · Fair commission / fee tolerance
+
+- **Country / region:** Lagos area, Nigeria.
+- **Fair commission for cashing out:** 1–3% feels reasonable to me — enough to compensate a provider for their time and liquidity risk, but low enough that the convenience is still worth it over walking to a bank or agent.
+- **Too-high threshold:** Anything above 5% and I would rather deal with the friction of a traditional channel. At that point the fee starts to feel exploitative rather than a fair service charge.
+- **What would justify a higher fee:** Not having to use a bank account at all is the biggest one for me — that alone unlocks access. Speed (same-day settlement) and a clear safety guarantee (verified provider, in-app dispute path) would also make me willing to stretch a little above my usual ceiling.
+- **Would I pay more for a closer / faster provider:** Yes. If the alternative is travelling further or waiting longer, a small premium for proximity and speed is worth it.
+
+### V-9 · Safety meeting in person
+
+>>>>>>> a84be11 (V-4: add non-custodial wallet onboarding response)
 First-person response (privacy-safe):
 
 - Do I receive money from abroad? Yes — via stablecoins on Stellar/Soroban and P2P networks.
@@ -158,6 +224,7 @@ First-person response (privacy-safe):
 **SDF narrative:** Extends the geographic sample beyond LATAM into South Asia, confirming that safety concerns around in-person exchange are universal. The safety design requirements that emerge are directly actionable for the provider matching screen UX.
 
 ### V-10 · Product validation: repeat use & provider discovery
+
 > Note: submitted in the earlier multi-respondent format (kept as-is). Newer entries are first-person.
 
 Small anonymized sample (N=4; self + 3 peers, convenience sample across Mexico and other Latin American regions):
@@ -187,6 +254,7 @@ Small anonymized sample (N=4; self + 3 peers, convenience sample across Mexico a
   - What would make them recommend it: a clear, low-friction experience that felt easy to explain to someone else.
 
 Aggregate signal:
+
 - Discovery is likely to happen through a map/list and search, with referrals acting as a trust multiplier.
 - Repeat use looks plausible if the first experience is fast, predictable, and visibly trustworthy.
 - The main risk to repeat use is uncertainty around provider quality, availability, and support.

--- a/docs/VALIDATION_DRIPS.md
+++ b/docs/VALIDATION_DRIPS.md
@@ -259,7 +259,14 @@ _(no responses yet)_
 - **What would make me switch?:** A cheaper, faster, and more transparent service with a reliable, immediate local cash-out path. The one thing that would have to be better is certainty: knowing the final amount received and the cash-out option before I send.
 
 ### V-14 · Stablecoin / digital peso mental model
-_(no responses yet)_
+**Contributor:** [@Max-Owolabi](https://github.com/Max-Owolabi) · **PR:** [#170](https://github.com/ericmt-98/micopay-protocol/pull/170)
+
+- **Country / general region:** Nigeria (West Africa)
+- **Have you ever held or used a digital stablecoin?:** Yes. I have held and used USDC and USDT on Stellar and other networks. I obtained them by purchasing through local exchange agents or peer-to-peer (P2P) platforms, and I used them to preserve value against local currency inflation and to pay for digital services online where local cards fail.
+- **How did you think about it compared to physical cash?:** Initially, it felt like an abstract number on a screen rather than "real money" since I couldn't physically spend it at local shops. However, knowing that I could convert it back to local fiat cash or use it for global payments built my trust. The smart contract locking mechanisms and transparent on-chain transactions also made it feel secure.
+- **What was the hardest part to understand about holding a digital token?:** The hardest part to understand initially was the gas/network fees concept, the difference between different blockchain networks (e.g., Stellar vs. Ethereum) for the same stablecoin, and managing self-custody keys without a centralized bank to reset passwords.
+- **If someone told you "your pesos/funds are now in a digital wallet on your phone," what would be your first reaction?:** My first reaction would be a mix of curiosity and slight caution. I would feel the money is safe from physical theft, but potentially at risk of digital hacking or user error (losing keys) unless the wallet provides clear, simplified security and recovery options.
+- **What would make a digital peso/stablecoin feel as reliable as cash in your hand?:** It would feel as reliable as cash if there was a guaranteed, instant way to convert it to physical cash at any local corner store without high fees or complex steps, alongside a clear in-app balance showing that the funds are secured by an escrow contract.
 
 ### V-15 · First-time trust threshold
 _(no responses yet)_

--- a/docs/VALIDATION_DRIPS.md
+++ b/docs/VALIDATION_DRIPS.md
@@ -102,16 +102,55 @@ _(no responses yet)_
 _(no responses yet)_
 
 ### V-6 · Remittances cash-out context
-_(no responses yet)_
+**Contributor:** [@KaruG1999](https://github.com/KaruG1999) · **PR:** [#146](https://github.com/ericmt-98/micopay-protocol/pull/146) · **Region:** Argentina (LATAM)
+
+First-person response (privacy-safe):
+
+- Do I receive money from abroad? Yes — via stablecoins on Stellar/Soroban and P2P networks.
+- How do I receive it today? Standard international banking wires trigger excessive regulatory friction, high inbound fees, and unfavorable official currency conversion rates. While crypto solves cross-border speed, cashing out stablecoins to local fiat still relies on P2P order books or physical OTC exchanges, with variable spread and counterparty risk.
+- Would a nearby, same-day cash-out point help me? Yes. Eliminating the P2P counterparty matching phase and having an immediate, same-day physical cash-out point nearby would drastically reduce friction and eliminate exchange-rate slippage.
+
+**SDF narrative:** Sharpest evidence for Claim 1 (demand exists) — a person who already uses Stellar for cross-border transfers and still lacks a trustworthy last-mile cash-out. MicoPay solves the final delivery step the network already carries.
 
 ### V-7 · Current alternatives & switching
-_(no responses yet)_
+**Contributor:** [@barnabasolutayo-lgtm](https://github.com/barnabasolutayo-lgtm) · **PR:** [#145](https://github.com/ericmt-98/micopay-protocol/pull/145) · **Regions:** Monterrey MX · Bogotá CO · Buenos Aires AR · Caracas VE
+
+Multi-respondent batch (N=4, anonymized):
+
+| Respondent | Current method | Main friction | Would switch for |
+|------------|---------------|---------------|-----------------|
+| Monterrey, MX | OXXO + bank ATM | High convenience fees, queues, downtime | Lower fees, neighborhood exchange points |
+| Bogotá, CO | Nequi / Daviplata + Efecty | App downtime, limits, high cash-out fees | 24/7 reliability, transparent fees, flexible limits |
+| Buenos Aires, AR | Informal exchange houses + Binance P2P | Physical safety risks, P2P counterparty trust | Verified, trust-rated merchant network |
+| Caracas, VE | Binance P2P + Pago Móvil + informal USD | Broker fees >5%, fiat/USD sourcing costs | Direct <2% connection to verified agents with escrow |
+
+Switching dealbreakers across all four: upfront fees before handover · no immediate confirmation receipt · high platform fees · mandatory multi-day KYC · transaction failures.
+
+**SDF narrative:** Validates Claim 3 (MicoPay can win) across four countries. Existing alternatives all fail on at least one of: fees, trust, or reliability — exactly what MicoPay addresses via Stellar escrow and reputation ratings.
 
 ### V-8 · Fair commission / fee tolerance
-_(no responses yet)_
+**Contributor:** [@rosemary21](https://github.com/rosemary21) · **PR:** [#148](https://github.com/ericmt-98/micopay-protocol/pull/148) · **Region:** Nigeria (Lagos area)
+
+First-person response (privacy-safe):
+
+- Fair fee range I would accept: 1–3% — enough to compensate the provider for time and liquidity risk, low enough that the service beats a traditional bank or agent.
+- "Too expensive" threshold: >5%. Above that it feels exploitative and the traditional channel wins by default.
+- What would justify stretching the ceiling: (1) not needing a bank account at all — that alone unlocks access; (2) same-day settlement; (3) verified provider + in-app dispute path.
+- Would I pay a premium for a closer / faster provider? Yes. Proximity and speed justify a small premium over the base rate.
+
+**SDF narrative:** Adds sub-Saharan Africa to the sample and contributes the clearest statement of the "no bank account needed" value proposition. The 1–5% fee band confirmed here matches signals from Venezuela and LATAM, establishing a cross-regional pricing anchor.
 
 ### V-9 · Safety meeting in person
-_(no responses yet)_
+**Contributor:** [@deep-bhikadiya](https://github.com/deep-bhikadiya) · **PR:** [#147](https://github.com/ericmt-98/micopay-protocol/pull/147) · **Region:** India / South Asia
+
+First-person response (privacy-safe):
+
+- Comfort level meeting a stranger to exchange cash: Neutral — I would not say I am fully comfortable, but I could do it if the meeting place, timing, and person all felt trustworthy.
+- Biggest safety fear: Being scammed or robbed. Secondary: fake cash, last-minute location change, being followed after leaving.
+- What would make it feel safe: A busy public place during the day. Verified profiles, ratings, in-app chat, clear receipts, and a way to contact support would make the exchange feel more controlled.
+- Preference — known shops vs individuals: I would prefer a known shop. It feels more accountable and easier to trace if something goes wrong. Meeting a random individual feels inherently more uncertain.
+
+**SDF narrative:** Extends the geographic sample beyond LATAM into South Asia, confirming that safety concerns around in-person exchange are universal. The safety design requirements that emerge are directly actionable for the provider matching screen UX.
 
 ### V-10 · Product validation: repeat use & provider discovery
 > Note: submitted in the earlier multi-respondent format (kept as-is). Newer entries are first-person.

--- a/docs/WAVE6_CONTRIBUTORS_REPORT.md
+++ b/docs/WAVE6_CONTRIBUTORS_REPORT.md
@@ -15,14 +15,18 @@
 
 | PR | GitHub user | Issue closed | Validation topic | Region | Status |
 |----|-------------|-------------|-----------------|--------|--------|
+| [#155](https://github.com/ericmt-98/micopay-protocol/pull/155) | [@larryjay007](https://github.com/larryjay007) | #131 | V-1 · Cash-out context | Nigeria (South West) | ✅ Merged |
+| [#159](https://github.com/ericmt-98/micopay-protocol/pull/159) | [@Truphile](https://github.com/Truphile) | #132 | V-2 · Cash-in / deposit context | Nigeria (West Africa) | ✅ Merged |
+| [#157](https://github.com/ericmt-98/micopay-protocol/pull/157) | [@Shadow-MMN](https://github.com/Shadow-MMN) | #134 | V-4 · Non-custodial wallet onboarding | — | ✅ Merged |
+| [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) | [@Truphile](https://github.com/Truphile) | #135 | V-5 · Trust in the cash-in/cash-out flow | Nigeria (West Africa) | ✅ Merged |
 | [#143](https://github.com/ericmt-98/micopay-protocol/pull/143) | [@attyolu](https://github.com/attyolu) | #142 | V-10 · Repeat use & provider discovery | Mexico / LATAM | ✅ Merged |
 | [#145](https://github.com/ericmt-98/micopay-protocol/pull/145) | [@barnabasolutayo-lgtm](https://github.com/barnabasolutayo-lgtm) | #139 | V-7 · Current alternatives & switching | Monterrey MX / Bogotá CO / Buenos Aires AR / Caracas VE | ✅ Merged |
 | [#146](https://github.com/ericmt-98/micopay-protocol/pull/146) | [@KaruG1999](https://github.com/KaruG1999) | #138 | V-6 · Remittances cash-out context | Argentina | ✅ Merged |
 | [#147](https://github.com/ericmt-98/micopay-protocol/pull/147) | [@deep-bhikadiya](https://github.com/deep-bhikadiya) | #141 | V-9 · Safety meeting in person | India / South Asia | ✅ Merged |
 | [#148](https://github.com/ericmt-98/micopay-protocol/pull/148) | [@rosemary21](https://github.com/rosemary21) | #140 | V-8 · Fair commission / fee tolerance | Nigeria (Lagos area) | ✅ Merged |
 
-**Total responses so far: N=8** (1 multi-respondent batch in V-10 + 4 first-person + 3 implicit in V-7 batch)
-**Regions represented:** Mexico, Colombia, Argentina, Venezuela, India, Nigeria
+**Total responses: N=12** (V-1, V-2, V-4, V-5 first-person + 1 multi-respondent batch in V-10 + 4 first-person V-6/V-8/V-9 + 3 implicit in V-7 batch)
+**Regions represented:** Nigeria (×3), Mexico, Colombia, Argentina, Venezuela, India
 
 ---
 
@@ -32,17 +36,91 @@ Each contribution advances one or more of the five claims in our funding narrati
 
 | SDF Claim | Issues that back it | Responses in so far | Gap |
 |-----------|--------------------|--------------------|-----|
-| **1. Demand exists** (people need cash ↔ digital conversion) | V-1, V-2, V-6 | V-6 ✅ (KaruG1999) | V-1 and V-2 still open |
-| **2. Supply exists** (providers would offer cash for a commission) | V-3 | None yet | V-3 unassigned |
+| **1. Demand exists** (people need cash ↔ digital conversion) | V-1, V-2, V-6 | V-1 ✅ (larryjay007) · V-2 ✅ (Truphile) · V-6 ✅ (KaruG1999) | Fully covered (3 responses) |
+| **2. Supply exists** (providers would offer cash for a commission) | V-3 | None yet | V-3 unassigned — **🔴 critical gap** |
 | **3. MicoPay can win** (better than current options, at an acceptable fee) | V-7, V-8 | V-7 ✅ (barnabasolutayo-lgtm) · V-8 ✅ (rosemary21) | Both covered |
-| **4. Stellar is usable** (mainstream users can handle non-custodial wallets) | V-4 | None yet | V-4 assigned to @Shadow-MMN, no PR yet |
-| **5. Trust & PMF** (users feel safe, would return, would recommend) | V-5, V-9, V-10 | V-9 ✅ (deep-bhikadiya) · V-10 ✅ (attyolu) | V-5 assigned to @Truphile, no PR yet |
+| **4. Stellar is usable** (mainstream users can handle non-custodial wallets) | V-4 | V-4 ✅ (Shadow-MMN) | Covered |
+| **5. Trust & PMF** (users feel safe, would return, would recommend) | V-5, V-9, V-10 | V-5 ✅ (Truphile) · V-9 ✅ (deep-bhikadiya) · V-10 ✅ (attyolu) | Fully covered (3 responses) |
 
-> **Priority to unlock:** V-1 (cash-out demand) and V-3 (liquidity supply) — the two core sides of the market. Without at least one response each, the funding case is missing its foundation.
+> **Only remaining gap:** V-3 (liquidity provider perspective) — the supply side of the market. Without a first-person provider viewpoint, the SDF supply-side argument is unsubstantiated.
 
 ---
 
 ## Detailed contribution entries
+
+---
+
+### V-1 · Cash-out context
+**Contributor:** [@larryjay007](https://github.com/larryjay007) · **PR:** [#155](https://github.com/ericmt-98/micopay-protocol/pull/155) · **Merged:** 2026-06-25
+
+**Format:** First-person, single respondent.
+
+**Region:** Nigeria (South West)
+
+**Key findings:**
+
+- **Cash-out frequency:** Weekly — a recurring, non-occasional need.
+- **Current method:** Peer-to-peer exchange or bank transfer to a local account, followed by ATM withdrawal or POS agent.
+- **Main friction:** High cumulative transaction fees, unreliable ATM availability, and daily withdrawal limits.
+- **Lived experience:** Spent over an hour visiting three bank locations due to empty ATMs and network failures. When a working ATM was finally found, the daily withdrawal limit forced multiple transactions and additional bank charges.
+
+**SDF narrative contribution:** Adds Nigeria (South West) to the cash-out demand signal for Claim 1. Weekly frequency + ATM reliability failures + withdrawal limits combine into a strong recurring pain that a local P2P agent network directly addresses.
+
+---
+
+### V-2 · Cash-in / deposit context
+**Contributor:** [@Truphile](https://github.com/Truphile) · **PR:** [#159](https://github.com/ericmt-98/micopay-protocol/pull/159) · **Merged:** 2026-06-25
+
+**Format:** First-person, single respondent.
+
+**Region:** Nigeria (West Africa)
+
+**Key findings:**
+
+- **Why cash-in matters:** Collecting paper cash from offline gigs or friends makes it impossible to pay digital bills (AWS, utility tokens, fintech savings). Cash-in = unblocking access to the digital economy.
+- **Current method:** Walk to a neighborhood PoS agent, hand over physical cash, provide account details, wait for a transfer to the digital wallet via the agent's terminal.
+- **Frequency:** A few times a month — whenever physical cash accumulates.
+- **Main trust barrier:** Network failures mid-transaction. The fear is handing over cash and hearing "network is bad, the money hasn't dropped yet." A reversal can take 24–48 hours.
+- **Local trusted providers:** Yes — established, branded kiosks tied to a permanent physical location. Reputation accountability makes them trustworthy.
+
+**SDF narrative contribution:** Confirms bidirectional demand (Claim 1) from West Africa. The cash-in direction mirrors the cash-out demand of V-1. The key UX risk to address: mid-operation network failure and confirmation latency must have an immediate in-app status solution.
+
+---
+
+### V-4 · Non-custodial wallet onboarding
+**Contributor:** [@Shadow-MMN](https://github.com/Shadow-MMN) · **PR:** [#157](https://github.com/ericmt-98/micopay-protocol/pull/157) · **Merged:** 2026-06-25
+
+**Format:** First-person UX audit of the current MicoPay app.
+
+**Key findings:**
+
+- **Key custody clarity:** Not clear at all. No onboarding screen exists — keypair was generated silently and only discoverable via browser localStorage inspection.
+- **Biggest fear:** Losing the key to a hacker since it is stored in localStorage without any user-visible protection.
+- **Minimum to build trust:** A dedicated first-launch screen explaining that a wallet was created, showing the public key, and prompting the user to back up the secret key.
+- **Create vs import:** Preference for importing an existing Stellar key — user already has funds elsewhere and doesn't want the friction of moving balances.
+- **Backup mandatory vs optional:** Optional, but the UI must make it trivially easy (single tap to copy + prominent safety note). Mandatory backup frustrates trial users; invisible backup frustrates serious users.
+
+**SDF narrative contribution:** First direct UX audit of the onboarding flow for Claim 4 (Stellar is usable). The verdict is clear: the current app does not meet the minimum bar for a non-technical user. The findings give the team a concrete, actionable checklist: onboarding screen → key display → copy-to-backup flow.
+
+---
+
+### V-5 · Trust in the cash-in/cash-out flow
+**Contributor:** [@Truphile](https://github.com/Truphile) · **PR:** [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) · **Merged:** 2026-06-25
+
+**Format:** First-person, single respondent.
+
+**Region:** Nigeria (West Africa)
+
+**Key findings:**
+
+- **Most trusted provider type:** A well-established, branded neighborhood PoS kiosk with a steady stream of customers and a dedicated Android PoS terminal.
+- **Least trusted:** A mobile, unbranded agent on a street corner with just a phone, or one claiming "network is bad" before even attempting the transaction.
+- **Minimum info before handing over cash:** (1) Exact commission fee stated upfront · (2) Final locked-in value that will reflect in the wallet · (3) Clear on-screen confirmation that the agent's system is active and online.
+- **Verification signals needed:** Agent's location and banner matching the in-app map listing + a "Trusted Agent" badge or high completion-rate indicator.
+- **Support expectation mid-failure:** Immediate automated SMS receipt or in-app "Pending / Money Received" status · a WhatsApp support channel or toll-free line resolving hanging transactions within minutes.
+- **Top abandonment trigger:** Any delay at point of payment — "network is fluctuating" or slow QR code/receipt generation triggers fear of trapped funds.
+
+**SDF narrative contribution:** Maps the trust and abandonment signals directly to Claim 5 (Trust / PMF). The three-part checklist — transparent fee, locked rate, online status — is a concrete UX requirement the agent flow must satisfy before cash changes hands. Combined with V-2, this builds the complete Nigeria trust picture.
 
 ---
 
@@ -152,16 +230,22 @@ Each contribution advances one or more of the five claims in our funding narrati
 Across Nigeria, Venezuela, Mexico, Colombia, and Argentina, respondents independently converge on the same range. Anything above 5% loses to the traditional channel — even for people with very limited access. This gives MicoPay a concrete, defensible pricing constraint.
 
 ### 2. Trust is not optional — it's the feature
-Every respondent across every topic mentioned trust signals as a prerequisite: verified profiles, ratings, in-app chat, receipts, support access. This is not a "nice to have" for the UX — it is the product's core value proposition alongside low fees.
+Every respondent across every topic mentioned trust signals as a prerequisite: verified profiles, ratings, in-app chat, receipts, support access. This is not a "nice to have" for the UX — it is the product's core value proposition alongside low fees. V-5 (Truphile) gives the sharpest articulation: three non-negotiable signals must appear before cash changes hands — transparent fee, locked rate, and online status confirmation.
 
 ### 3. The last mile is the real problem, even for Stellar users
 The Argentina respondent (V-6) already uses Stellar for cross-border transfers and still can't get cash locally without P2P counterparty risk. MicoPay's value isn't the blockchain — it's the trusted, local, same-day cash delivery.
 
 ### 4. The "no bank account required" argument is the strongest unlock
-Named explicitly by Nigeria (V-8) and implied by Venezuela (V-7). For sub-Saharan Africa and hyper-inflationary LATAM economies, eliminating bank account dependency is more compelling than any fee argument.
+Named explicitly by Nigeria (V-8) and implied by Venezuela (V-7) and confirmed directionally by V-2 (Truphile): digital cash-in is the gateway to the digital economy for people whose income arrives in paper. For sub-Saharan Africa and hyper-inflationary LATAM economies, eliminating bank account dependency is more compelling than any fee argument.
 
-### 5. Geographic diversity de-risks the SDF case
-Responses now span 6 countries across 3 continents (LATAM, South Asia, Africa). The convergence of pain points and preferences across such different markets strengthens the case that this is a structural problem — not a local quirk — and that Stellar's infrastructure can solve it globally.
+### 5. The wallet onboarding is currently broken — V-4 proves it
+Shadow-MMN's audit (V-4) found the app generates a keypair silently, stores it in localStorage with no user notification, and has no backup prompt. This is a critical gap for Claim 4. The fix is well-defined: first-launch onboarding screen → public key display → one-tap secret key backup. This must ship before any SDF demo.
+
+### 6. Network failure at the moment of cash transfer is the #1 trust killer
+Both V-2 and V-5 (West Africa) independently identify the same abandonment trigger: handing over physical cash and then hearing "network is bad." This points to a single, high-priority product requirement — real-time transaction status feedback (SMS or in-app) must be immediate and unambiguous, with a clear resolution path (WhatsApp / toll-free line).
+
+### 7. Geographic diversity de-risks the SDF case
+Responses now span 6+ countries across 3 continents (LATAM, South Asia, Africa). The convergence of pain points and preferences across such different markets strengthens the case that this is a structural problem — not a local quirk — and that Stellar's infrastructure can solve it globally.
 
 ---
 
@@ -185,9 +269,9 @@ Responses now span 6 countries across 3 continents (LATAM, South Asia, Africa). 
 - **First-person** entries reflect each contributor's own lived experience — not a survey of others.
 - **Convenience sample**, self-selected via Stellar Drips Wave 6. Directional and qualitative, not statistically representative.
 - **Privacy-first:** no names, no contact information, no transaction amounts, no wallet addresses.
-- Current sample size: **N=8 individual perspectives** across **6 countries / 3 regions**.
+- Current sample size: **N=12 individual perspectives** across **6+ countries / 3 regions**.
 - Report `N` plainly. Let the cross-regional consistency of the patterns speak for itself.
 
 ---
 
-*Last updated: 2026-06-24 · Maintainer: [@ericmt-98](https://github.com/ericmt-98)*
+*Last updated: 2026-06-25 · Maintainer: [@ericmt-98](https://github.com/ericmt-98)*

--- a/docs/WAVE6_CONTRIBUTORS_REPORT.md
+++ b/docs/WAVE6_CONTRIBUTORS_REPORT.md
@@ -16,21 +16,22 @@
 | PR | GitHub user | Issue closed | Validation topic | Region | Status |
 |----|-------------|-------------|-----------------|--------|--------|
 | [#155](https://github.com/ericmt-98/micopay-protocol/pull/155) | [@larryjay007](https://github.com/larryjay007) | #131 | V-1 · Cash-out context | Nigeria (South West) | ✅ Merged |
-| [#159](https://github.com/ericmt-98/micopay-protocol/pull/159) | [@Truphile](https://github.com/Truphile) | #132 | V-2 · Cash-in / deposit context | Nigeria (West Africa) | ✅ Merged |
+| [#159](https://github.com/ericmt-98/micopay-protocol/pull/159) | [@Truphile](https://github.com/Truphile) | #132 | V-2 · Cash-in / deposit context | Nigeria (West Africa) | ✅ Integrated |
 | [#157](https://github.com/ericmt-98/micopay-protocol/pull/157) | [@Shadow-MMN](https://github.com/Shadow-MMN) | #134 | V-4 · Non-custodial wallet onboarding | — | ✅ Merged |
-| [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) | [@Truphile](https://github.com/Truphile) | #135 | V-5 · Trust in the cash-in/cash-out flow | Nigeria (West Africa) | ✅ Merged |
+| [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) | [@Truphile](https://github.com/Truphile) | #135 | V-5 · Trust in the cash-in/cash-out flow | Nigeria (West Africa) | ✅ Integrated |
 | [#143](https://github.com/ericmt-98/micopay-protocol/pull/143) | [@attyolu](https://github.com/attyolu) | #142 | V-10 · Repeat use & provider discovery | Mexico / LATAM | ✅ Merged |
 | [#145](https://github.com/ericmt-98/micopay-protocol/pull/145) | [@barnabasolutayo-lgtm](https://github.com/barnabasolutayo-lgtm) | #139 | V-7 · Current alternatives & switching | Monterrey MX / Bogotá CO / Buenos Aires AR / Caracas VE | ✅ Merged |
 | [#146](https://github.com/ericmt-98/micopay-protocol/pull/146) | [@KaruG1999](https://github.com/KaruG1999) | #138 | V-6 · Remittances cash-out context | Argentina | ✅ Merged |
 | [#147](https://github.com/ericmt-98/micopay-protocol/pull/147) | [@deep-bhikadiya](https://github.com/deep-bhikadiya) | #141 | V-9 · Safety meeting in person | India / South Asia | ✅ Merged |
 | [#148](https://github.com/ericmt-98/micopay-protocol/pull/148) | [@rosemary21](https://github.com/rosemary21) | #140 | V-8 · Fair commission / fee tolerance | Nigeria (Lagos area) | ✅ Merged |
 | [#169](https://github.com/ericmt-98/micopay-protocol/pull/169) | [@DevSolex](https://github.com/DevSolex) | #133 | V-3 · Liquidity provider perspective | Nigeria (West Africa) | ✅ Merged |
-| [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) | [@Jo-anny](https://github.com/Jo-anny) | #166 | V-13 · Remittance sender context | Europe → Latin America | ✅ Merged |
+| [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) | [@Jo-anny](https://github.com/Jo-anny) | #166 | V-13 · Remittance sender context | Europe → Latin America | ✅ Integrated |
 | [#173](https://github.com/ericmt-98/micopay-protocol/pull/173) | [@Oluwasuyi-Timilehin](https://github.com/Oluwasuyi-Timilehin) | #165 | V-12 · Living unbanked — daily cash management | Mexico (CDMX) | ✅ Merged |
-| [#170](https://github.com/ericmt-98/micopay-protocol/pull/170) | [@Max-Owolabi](https://github.com/Max-Owolabi) | #167 | V-14 · Stablecoin / digital peso mental model | Nigeria (West Africa) | ✅ Merged |
+| [#175](https://github.com/ericmt-98/micopay-protocol/pull/175) | [@Max-Owolabi](https://github.com/Max-Owolabi) | #167 | V-14 · Stablecoin / digital peso mental model | Nigeria (West Africa) | ✅ Integrated |
+| [#174](https://github.com/ericmt-98/micopay-protocol/pull/174) | [@Chigybillionz](https://github.com/Chigybillionz) | #164 | V-11 · Failed transaction / dispute handling | Nigeria (West Africa) | ✅ Integrated |
 
-**Total responses: N=16** (V-1, V-2, V-3, V-4, V-5, V-12, V-13, V-14 first-person + 1 multi-respondent batch in V-10 + 3 first-person V-6/V-8/V-9 + 3 implicit in V-7 batch)
-**Regions represented:** Nigeria (×5), Mexico (×2), Colombia, Argentina, Venezuela, India, Europe
+**Total responses: N=17** (V-1, V-2, V-3, V-4, V-5, V-11, V-12, V-13, V-14 first-person + 1 multi-respondent batch in V-10 + 3 first-person V-6/V-8/V-9 + 3 implicit in V-7 batch)
+**Regions represented:** Nigeria (×6), Mexico (×2), Colombia, Argentina, Venezuela, India, Europe
 
 ---
 
@@ -43,10 +44,10 @@ Each contribution advances one or more of the five claims in our funding narrati
 | **1. Demand exists** (people need cash ↔ digital conversion) | V-1, V-2, V-6 | V-1 ✅ (larryjay007) · V-2 ✅ (Truphile) · V-6 ✅ (KaruG1999) | Fully covered (3 responses) |
 | **2. Supply exists** (providers would offer cash for a commission) | V-3 | V-3 ✅ (DevSolex) | Covered — Nigeria individual provider |
 | **3. MicoPay can win** (better than current options, at an acceptable fee) | V-7, V-8 | V-7 ✅ (barnabasolutayo-lgtm) · V-8 ✅ (rosemary21) | Both covered |
-| **4. Stellar is usable** (mainstream users can handle non-custodial wallets) | V-4 | V-4 ✅ (Shadow-MMN) | Covered |
-| **5. Trust & PMF** (users feel safe, would return, would recommend) | V-5, V-9, V-10 | V-5 ✅ (Truphile) · V-9 ✅ (deep-bhikadiya) · V-10 ✅ (attyolu) | Fully covered (3 responses) |
+| **4. Stellar is usable** (mainstream users can handle non-custodial wallets) | V-4, V-14 | V-4 ✅ (Shadow-MMN) · V-14 ✅ (Max-Owolabi) | Covered (2 responses) |
+| **5. Trust & PMF** (users feel safe, would return, would recommend) | V-5, V-9, V-10, V-11 | V-5 ✅ (Truphile) · V-9 ✅ (deep-bhikadiya) · V-10 ✅ (attyolu) · V-11 ✅ (Chigybillionz) | Fully covered (4 responses) |
 
-> **All 5 SDF claims now have at least one response.** The supply-side gap (V-3) was closed by DevSolex. Remaining open validation issues (V-11, V-12, V-14, V-15) strengthen the deck but are not blocking the core funding case.
+> **All 5 SDF claims now have at least one response.** The supply-side gap (V-3) was closed by DevSolex. The only remaining open validation issue is **V-15** (first-time trust threshold); it strengthens the deck but is not blocking the core funding case.
 
 ---
 
@@ -306,6 +307,25 @@ Each contribution advances one or more of the five claims in our funding narrati
 
 ---
 
+### V-11 · Failed transaction / dispute handling
+**Contributor:** [@Chigybillionz](https://github.com/Chigybillionz) · **PR:** [#174](https://github.com/ericmt-98/micopay-protocol/pull/174) · **Integrated:** 2026-06-27
+
+**Format:** First-person, single respondent.
+
+**Region:** Nigeria (West Africa)
+
+**Key findings:**
+
+- **The failure:** A bank-to-bank transfer failed at the very last step — right after entering the correct OTP — returning only a generic "failed" error with no explanation.
+- **Recovery path:** No in-app recovery. The respondent fell back to an informal network (a relative sent cash) to complete the original purchase.
+- **Time-to-resolution:** Over a week and still unresolved; the only escalation path is a physical branch visit, which hadn't happened yet.
+- **What was missing:** Two concrete product gaps — (1) an immediate, plain-language status/explanation after the failure point, and (2) accessible support that doesn't require visiting a branch.
+- **Behavioral impact:** Eroded trust in the bank's transfer reliability ("it can fail at any point, even at the final stage"), though not enough to switch banks — because switching is itself high-friction.
+
+**SDF narrative contribution:** Sharpens Claim 5 (Trust / PMF) from the failure angle. Reinforces the V-2/V-5 finding that the moment of failure is the trust killer — but adds the *post*-failure dimension: a clear status explanation and a non-branch support/dispute path are product requirements, not nice-to-haves. MicoPay's escrow + in-app status + visible dispute path directly answer this pain.
+
+---
+
 ## Cross-cutting insights (for the SDF deck)
 
 ### 1. The fee ceiling is universal: 2–5%
@@ -336,15 +356,16 @@ Responses now span 6+ countries across 3 continents (LATAM, South Asia, Africa).
 | Issue | Assignee | PR | Status |
 |-------|----------|----|-----------------------|
 | V-1 · Cash-out demand | [@larryjay007](https://github.com/larryjay007) | [#155](https://github.com/ericmt-98/micopay-protocol/pull/155) ✅ | Merged — Nigeria (South West) |
-| V-2 · Cash-in / deposit context | [@Truphile](https://github.com/Truphile) | [#159](https://github.com/ericmt-98/micopay-protocol/pull/159) ✅ | Merged — Nigeria (West Africa) |
+| V-2 · Cash-in / deposit context | [@Truphile](https://github.com/Truphile) | [#159](https://github.com/ericmt-98/micopay-protocol/pull/159) ✅ | Integrated — Nigeria (West Africa) |
 | V-3 · Liquidity provider perspective | [@DevSolex](https://github.com/DevSolex) | [#169](https://github.com/ericmt-98/micopay-protocol/pull/169) ✅ | Merged — Nigeria (West Africa) |
 | V-4 · Non-custodial wallet onboarding | [@Shadow-MMN](https://github.com/Shadow-MMN) | [#157](https://github.com/ericmt-98/micopay-protocol/pull/157) ✅ | Merged |
-| V-5 · Trust in the flow | [@Truphile](https://github.com/Truphile) | [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) ✅ | Merged — Nigeria (West Africa) |
+| V-5 · Trust in the flow | [@Truphile](https://github.com/Truphile) | [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) ✅ | Integrated — Nigeria (West Africa) |
+| V-11 · Failed transaction / dispute | [@Chigybillionz](https://github.com/Chigybillionz) | [#174](https://github.com/ericmt-98/micopay-protocol/pull/174) ✅ | Integrated — Nigeria (West Africa) |
 | V-12 · Living unbanked | [@Oluwasuyi-Timilehin](https://github.com/Oluwasuyi-Timilehin) | [#173](https://github.com/ericmt-98/micopay-protocol/pull/173) ✅ | Merged — Mexico (CDMX) |
-| V-13 · Remittance sender context | [@Jo-anny](https://github.com/Jo-anny) | [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) ✅ | Merged — Europe → LATAM |
-| V-14 · Stablecoin mental model | [@Max-Owolabi](https://github.com/Max-Owolabi) | [#170](https://github.com/ericmt-98/micopay-protocol/pull/170) ✅ | Merged — Nigeria (West Africa) |
+| V-13 · Remittance sender context | [@Jo-anny](https://github.com/Jo-anny) | [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) ✅ | Integrated — Europe → LATAM |
+| V-14 · Stablecoin mental model | [@Max-Owolabi](https://github.com/Max-Owolabi) | [#175](https://github.com/ericmt-98/micopay-protocol/pull/175) ✅ | Integrated — Nigeria (West Africa) |
 
-> All five SDF claims now have coverage. Open issues: V-11, V-15.
+> All five SDF claims now have coverage. Only open issue: V-15 (first-time trust threshold).
 
 ---
 

--- a/docs/WAVE6_CONTRIBUTORS_REPORT.md
+++ b/docs/WAVE6_CONTRIBUTORS_REPORT.md
@@ -27,9 +27,10 @@
 | [#169](https://github.com/ericmt-98/micopay-protocol/pull/169) | [@DevSolex](https://github.com/DevSolex) | #133 | V-3 · Liquidity provider perspective | Nigeria (West Africa) | ✅ Merged |
 | [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) | [@Jo-anny](https://github.com/Jo-anny) | #166 | V-13 · Remittance sender context | Europe → Latin America | ✅ Merged |
 | [#173](https://github.com/ericmt-98/micopay-protocol/pull/173) | [@Oluwasuyi-Timilehin](https://github.com/Oluwasuyi-Timilehin) | #165 | V-12 · Living unbanked — daily cash management | Mexico (CDMX) | ✅ Merged |
+| [#170](https://github.com/ericmt-98/micopay-protocol/pull/170) | [@Max-Owolabi](https://github.com/Max-Owolabi) | #167 | V-14 · Stablecoin / digital peso mental model | Nigeria (West Africa) | ✅ Merged |
 
-**Total responses: N=15** (V-1, V-2, V-3, V-4, V-5, V-12, V-13 first-person + 1 multi-respondent batch in V-10 + 3 first-person V-6/V-8/V-9 + 3 implicit in V-7 batch)
-**Regions represented:** Nigeria (×4), Mexico (×2), Colombia, Argentina, Venezuela, India, Europe
+**Total responses: N=16** (V-1, V-2, V-3, V-4, V-5, V-12, V-13, V-14 first-person + 1 multi-respondent batch in V-10 + 3 first-person V-6/V-8/V-9 + 3 implicit in V-7 batch)
+**Regions represented:** Nigeria (×5), Mexico (×2), Colombia, Argentina, Venezuela, India, Europe
 
 ---
 
@@ -227,6 +228,25 @@ Each contribution advances one or more of the five claims in our funding narrati
 
 ---
 
+### V-14 · Stablecoin / digital peso mental model
+**Contributor:** [@Max-Owolabi](https://github.com/Max-Owolabi) · **PR:** [#170](https://github.com/ericmt-98/micopay-protocol/pull/170) · **Merged:** 2026-06-26
+
+**Format:** First-person, single respondent.
+
+**Region:** Nigeria (West Africa)
+
+**Key findings:**
+
+- **Prior stablecoin experience:** Yes — USDC and USDT on Stellar and other networks, obtained via local exchange agents and P2P platforms. Used primarily to hedge against local currency inflation and pay for digital services where local cards fail.
+- **Mental model vs physical cash:** Initially abstract ("a number on a screen"). Trust built through: ability to convert back to fiat, global payment utility, smart contract security, on-chain transaction transparency.
+- **Hardest part to understand:** Gas/network fees, multi-chain differences for the same token (Stellar vs Ethereum), and self-custody key management without a bank password reset.
+- **Reaction to "your funds are in a digital wallet":** Curiosity + caution — safer from physical theft, but fears digital hacking or key loss without clear recovery options.
+- **Cash equivalence trigger:** Guaranteed instant conversion to cash at any local corner store, no high fees, and clear in-app escrow confirmation.
+
+**SDF narrative contribution:** Validates Claim 4 (Stellar is usable) from an inflationary market. Stablecoins are already valued as a real tool in West Africa — the gap is the last-mile cash conversion and key recovery UX, which is exactly what MicoPay's local agent + escrow model addresses.
+
+---
+
 ### V-12 · Living unbanked — everyday context
 **Contributor:** [@Oluwasuyi-Timilehin](https://github.com/Oluwasuyi-Timilehin) · **PR:** [#173](https://github.com/ericmt-98/micopay-protocol/pull/173) · **Merged:** 2026-06-26
 
@@ -322,8 +342,9 @@ Responses now span 6+ countries across 3 continents (LATAM, South Asia, Africa).
 | V-5 · Trust in the flow | [@Truphile](https://github.com/Truphile) | [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) ✅ | Merged — Nigeria (West Africa) |
 | V-12 · Living unbanked | [@Oluwasuyi-Timilehin](https://github.com/Oluwasuyi-Timilehin) | [#173](https://github.com/ericmt-98/micopay-protocol/pull/173) ✅ | Merged — Mexico (CDMX) |
 | V-13 · Remittance sender context | [@Jo-anny](https://github.com/Jo-anny) | [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) ✅ | Merged — Europe → LATAM |
+| V-14 · Stablecoin mental model | [@Max-Owolabi](https://github.com/Max-Owolabi) | [#170](https://github.com/ericmt-98/micopay-protocol/pull/170) ✅ | Merged — Nigeria (West Africa) |
 
-> All five SDF claims now have coverage. Open issues: V-11, V-14, V-15.
+> All five SDF claims now have coverage. Open issues: V-11, V-15.
 
 ---
 
@@ -332,7 +353,7 @@ Responses now span 6+ countries across 3 continents (LATAM, South Asia, Africa).
 - **First-person** entries reflect each contributor's own lived experience — not a survey of others.
 - **Convenience sample**, self-selected via Stellar Drips Wave 6. Directional and qualitative, not statistically representative.
 - **Privacy-first:** no names, no contact information, no transaction amounts, no wallet addresses.
-- Current sample size: **N=15 individual perspectives** across **7+ countries / 3 regions**.
+- Current sample size: **N=16 individual perspectives** across **7+ countries / 3 regions**.
 - Report `N` plainly. Let the cross-regional consistency of the patterns speak for itself.
 
 ---

--- a/docs/WAVE6_CONTRIBUTORS_REPORT.md
+++ b/docs/WAVE6_CONTRIBUTORS_REPORT.md
@@ -167,17 +167,16 @@ Responses now span 6 countries across 3 continents (LATAM, South Asia, Africa). 
 
 ## What's still missing
 
-| Issue | Assignee | PR | Priority for SDF case |
+| Issue | Assignee | PR | Status |
 |-------|----------|----|-----------------------|
-| V-1 · Cash-out demand | [@larryjay007](https://github.com/larryjay007) | None yet | 🔴 Critical — core demand signal |
-| V-2 · Cash-in / deposit context | [@Truphile](https://github.com/Truphile) | None yet | 🔴 Critical — bidirectional demand |
+| V-1 · Cash-out demand | [@larryjay007](https://github.com/larryjay007) | [#155](https://github.com/ericmt-98/micopay-protocol/pull/155) ✅ | Merged — Nigeria (South West) |
+| V-2 · Cash-in / deposit context | [@Truphile](https://github.com/Truphile) | [#159](https://github.com/ericmt-98/micopay-protocol/pull/159) ✅ | Merged — Nigeria (West Africa) |
 | V-3 · Liquidity provider perspective | [@3m1n3nc3](https://github.com/3m1n3nc3) | None yet | 🔴 Critical — supply side of the market |
-| V-4 · Non-custodial wallet onboarding | [@Shadow-MMN](https://github.com/Shadow-MMN) | None yet | 🟡 Important — Stellar usability claim |
-| V-5 · Trust in the flow | [@Truphile](https://github.com/Truphile) | None yet | 🟡 Important — PMF / drop-off risk |
+| V-4 · Non-custodial wallet onboarding | [@Shadow-MMN](https://github.com/Shadow-MMN) | [#157](https://github.com/ericmt-98/micopay-protocol/pull/157) ✅ | Merged |
+| V-5 · Trust in the flow | [@Truphile](https://github.com/Truphile) | [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) ✅ | Merged — Nigeria (West Africa) |
 
-> V-1, V-2 and V-3 are the highest priority. Without at least one first-person response for each,
-> the SDF narrative lacks its two most fundamental claims: that people need this (demand) and
-> that someone would provide it (supply).
+> V-3 is the remaining critical gap. Without a first-person liquidity-provider perspective,
+> the supply side of the SDF narrative is unsubstantiated.
 
 ---
 

--- a/docs/WAVE6_CONTRIBUTORS_REPORT.md
+++ b/docs/WAVE6_CONTRIBUTORS_REPORT.md
@@ -24,9 +24,11 @@
 | [#146](https://github.com/ericmt-98/micopay-protocol/pull/146) | [@KaruG1999](https://github.com/KaruG1999) | #138 | V-6 · Remittances cash-out context | Argentina | ✅ Merged |
 | [#147](https://github.com/ericmt-98/micopay-protocol/pull/147) | [@deep-bhikadiya](https://github.com/deep-bhikadiya) | #141 | V-9 · Safety meeting in person | India / South Asia | ✅ Merged |
 | [#148](https://github.com/ericmt-98/micopay-protocol/pull/148) | [@rosemary21](https://github.com/rosemary21) | #140 | V-8 · Fair commission / fee tolerance | Nigeria (Lagos area) | ✅ Merged |
+| [#169](https://github.com/ericmt-98/micopay-protocol/pull/169) | [@DevSolex](https://github.com/DevSolex) | #133 | V-3 · Liquidity provider perspective | Nigeria (West Africa) | ✅ Merged |
+| [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) | [@Jo-anny](https://github.com/Jo-anny) | #166 | V-13 · Remittance sender context | Europe → Latin America | ✅ Merged |
 
-**Total responses: N=12** (V-1, V-2, V-4, V-5 first-person + 1 multi-respondent batch in V-10 + 4 first-person V-6/V-8/V-9 + 3 implicit in V-7 batch)
-**Regions represented:** Nigeria (×3), Mexico, Colombia, Argentina, Venezuela, India
+**Total responses: N=14** (V-1, V-2, V-3, V-4, V-5, V-13 first-person + 1 multi-respondent batch in V-10 + 3 first-person V-6/V-8/V-9 + 3 implicit in V-7 batch)
+**Regions represented:** Nigeria (×4), Mexico, Colombia, Argentina, Venezuela, India, Europe
 
 ---
 
@@ -37,12 +39,12 @@ Each contribution advances one or more of the five claims in our funding narrati
 | SDF Claim | Issues that back it | Responses in so far | Gap |
 |-----------|--------------------|--------------------|-----|
 | **1. Demand exists** (people need cash ↔ digital conversion) | V-1, V-2, V-6 | V-1 ✅ (larryjay007) · V-2 ✅ (Truphile) · V-6 ✅ (KaruG1999) | Fully covered (3 responses) |
-| **2. Supply exists** (providers would offer cash for a commission) | V-3 | None yet | V-3 unassigned — **🔴 critical gap** |
+| **2. Supply exists** (providers would offer cash for a commission) | V-3 | V-3 ✅ (DevSolex) | Covered — Nigeria individual provider |
 | **3. MicoPay can win** (better than current options, at an acceptable fee) | V-7, V-8 | V-7 ✅ (barnabasolutayo-lgtm) · V-8 ✅ (rosemary21) | Both covered |
 | **4. Stellar is usable** (mainstream users can handle non-custodial wallets) | V-4 | V-4 ✅ (Shadow-MMN) | Covered |
 | **5. Trust & PMF** (users feel safe, would return, would recommend) | V-5, V-9, V-10 | V-5 ✅ (Truphile) · V-9 ✅ (deep-bhikadiya) · V-10 ✅ (attyolu) | Fully covered (3 responses) |
 
-> **Only remaining gap:** V-3 (liquidity provider perspective) — the supply side of the market. Without a first-person provider viewpoint, the SDF supply-side argument is unsubstantiated.
+> **All 5 SDF claims now have at least one response.** The supply-side gap (V-3) was closed by DevSolex. Remaining open validation issues (V-11, V-12, V-14, V-15) strengthen the deck but are not blocking the core funding case.
 
 ---
 
@@ -224,6 +226,46 @@ Each contribution advances one or more of the five claims in our funding narrati
 
 ---
 
+### V-3 · Liquidity provider perspective
+**Contributor:** [@DevSolex](https://github.com/DevSolex) · **PR:** [#169](https://github.com/ericmt-98/micopay-protocol/pull/169) · **Merged:** 2026-06-26
+
+**Format:** First-person, single respondent.
+
+**Region:** Nigeria (West Africa)
+
+**Key findings:**
+
+- **Would provide liquidity?** Yes — with conditions: escrow must lock funds before cash is handed over.
+- **Provider type:** Individual with an informal side-hustle; handles modest cash flows and does occasional P2P exchanges locally.
+- **Main motivation:** Commission income + convenience of converting already-held stablecoins back to local currency without going through a bank. Also builds local reputation.
+- **Perceived risks:** Non-payment or fake/reversed digital transfer; physical safety when carrying cash in public; regulatory ambiguity; no clear dispute resolution path.
+- **Expected commission:** 2–3%. Below 2% doesn't cover time/liquidity risk; above 4% pushes users back to informal channels.
+- **Trust trigger:** USDC locked in escrow before any cash is handed over — removes most of the risk. Also: verified counterparty history, clear in-app step-by-step instructions, visible support/dispute path.
+
+**SDF narrative contribution:** Closes the supply-side gap for Claim 2. Confirms real willingness to provide liquidity among informal P2P exchangers in West Africa, and pins the commission range at 2–3% — consistent with the 1–5% window from V-8. The escrow-first design requirement is the clearest product signal: the escrow lock must be visible to the provider before they move any cash.
+
+---
+
+### V-13 · Remittance sender context — sending money abroad
+**Contributor:** [@Jo-anny](https://github.com/Jo-anny) · **PR:** [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) · **Merged:** 2026-06-26
+
+**Format:** First-person, single respondent.
+
+**Region:** Europe → Latin America (sender side)
+
+**Key findings:**
+
+- **Current method:** Mix of bank transfers and digital remittance services; sometimes crypto P2P for faster cash access.
+- **Cost:** High single-digit percent range (fees + currency conversion spread combined).
+- **Delivery time:** Same day to next day normally; banks can take several days if compliance checks trigger.
+- **Biggest frustration:** Opacity — unknown final delivered amount until after the transaction clears. Recipient must also handle separate cash-out steps or agent availability.
+- **Recipient behavior:** Cashes out via bank deposit, cash pickup, or mobile wallet + agent withdrawal.
+- **Switch trigger:** Cheaper, faster, more transparent — and crucially, knowing the final received amount and cash-out option **before** sending.
+
+**SDF narrative contribution:** Adds the sender-side view to the remittance demand signal (Claim 1). The V-6 Argentina response covered the receiver; V-13 closes the loop from the sender. The "certainty before sending" requirement is a direct product spec: the trade confirmation screen must show the exact MXN-equivalent and nearby provider availability before the user commits.
+
+---
+
 ## Cross-cutting insights (for the SDF deck)
 
 ### 1. The fee ceiling is universal: 2–5%
@@ -255,12 +297,12 @@ Responses now span 6+ countries across 3 continents (LATAM, South Asia, Africa).
 |-------|----------|----|-----------------------|
 | V-1 · Cash-out demand | [@larryjay007](https://github.com/larryjay007) | [#155](https://github.com/ericmt-98/micopay-protocol/pull/155) ✅ | Merged — Nigeria (South West) |
 | V-2 · Cash-in / deposit context | [@Truphile](https://github.com/Truphile) | [#159](https://github.com/ericmt-98/micopay-protocol/pull/159) ✅ | Merged — Nigeria (West Africa) |
-| V-3 · Liquidity provider perspective | [@3m1n3nc3](https://github.com/3m1n3nc3) | None yet | 🔴 Critical — supply side of the market |
+| V-3 · Liquidity provider perspective | [@DevSolex](https://github.com/DevSolex) | [#169](https://github.com/ericmt-98/micopay-protocol/pull/169) ✅ | Merged — Nigeria (West Africa) |
 | V-4 · Non-custodial wallet onboarding | [@Shadow-MMN](https://github.com/Shadow-MMN) | [#157](https://github.com/ericmt-98/micopay-protocol/pull/157) ✅ | Merged |
 | V-5 · Trust in the flow | [@Truphile](https://github.com/Truphile) | [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) ✅ | Merged — Nigeria (West Africa) |
+| V-13 · Remittance sender context | [@Jo-anny](https://github.com/Jo-anny) | [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) ✅ | Merged — Europe → LATAM |
 
-> V-3 is the remaining critical gap. Without a first-person liquidity-provider perspective,
-> the supply side of the SDF narrative is unsubstantiated.
+> All five SDF claims now have coverage. Open issues: V-11, V-12, V-14, V-15.
 
 ---
 
@@ -269,9 +311,9 @@ Responses now span 6+ countries across 3 continents (LATAM, South Asia, Africa).
 - **First-person** entries reflect each contributor's own lived experience — not a survey of others.
 - **Convenience sample**, self-selected via Stellar Drips Wave 6. Directional and qualitative, not statistically representative.
 - **Privacy-first:** no names, no contact information, no transaction amounts, no wallet addresses.
-- Current sample size: **N=12 individual perspectives** across **6+ countries / 3 regions**.
+- Current sample size: **N=14 individual perspectives** across **7+ countries / 3 regions**.
 - Report `N` plainly. Let the cross-regional consistency of the patterns speak for itself.
 
 ---
 
-*Last updated: 2026-06-25 · Maintainer: [@ericmt-98](https://github.com/ericmt-98)*
+*Last updated: 2026-06-26 · Maintainer: [@ericmt-98](https://github.com/ericmt-98)*

--- a/docs/WAVE6_CONTRIBUTORS_REPORT.md
+++ b/docs/WAVE6_CONTRIBUTORS_REPORT.md
@@ -170,8 +170,8 @@ Responses now span 6 countries across 3 continents (LATAM, South Asia, Africa). 
 | Issue | Assignee | PR | Priority for SDF case |
 |-------|----------|----|-----------------------|
 | V-1 · Cash-out demand | [@larryjay007](https://github.com/larryjay007) | None yet | 🔴 Critical — core demand signal |
-| V-2 · Cash-in / deposit context | Unassigned | None yet | 🔴 Critical — bidirectional demand |
-| V-3 · Liquidity provider perspective | Unassigned | None yet | 🔴 Critical — supply side of the market |
+| V-2 · Cash-in / deposit context | [@Truphile](https://github.com/Truphile) | None yet | 🔴 Critical — bidirectional demand |
+| V-3 · Liquidity provider perspective | [@3m1n3nc3](https://github.com/3m1n3nc3) | None yet | 🔴 Critical — supply side of the market |
 | V-4 · Non-custodial wallet onboarding | [@Shadow-MMN](https://github.com/Shadow-MMN) | None yet | 🟡 Important — Stellar usability claim |
 | V-5 · Trust in the flow | [@Truphile](https://github.com/Truphile) | None yet | 🟡 Important — PMF / drop-off risk |
 

--- a/docs/WAVE6_CONTRIBUTORS_REPORT_ES.md
+++ b/docs/WAVE6_CONTRIBUTORS_REPORT_ES.md
@@ -16,21 +16,22 @@
 | PR | Usuario de GitHub | Issue cerrado | Tema validado | Región | Estado |
 |----|-------------------|--------------|--------------|--------|--------|
 | [#155](https://github.com/ericmt-98/micopay-protocol/pull/155) | [@larryjay007](https://github.com/larryjay007) | #131 | V-1 · Contexto de cash-out | Nigeria (Sur Oeste) | ✅ Mergeado |
-| [#159](https://github.com/ericmt-98/micopay-protocol/pull/159) | [@Truphile](https://github.com/Truphile) | #132 | V-2 · Contexto de cash-in / depósito | Nigeria (África Occidental) | ✅ Mergeado |
+| [#159](https://github.com/ericmt-98/micopay-protocol/pull/159) | [@Truphile](https://github.com/Truphile) | #132 | V-2 · Contexto de cash-in / depósito | Nigeria (África Occidental) | ✅ Integrado |
 | [#157](https://github.com/ericmt-98/micopay-protocol/pull/157) | [@Shadow-MMN](https://github.com/Shadow-MMN) | #134 | V-4 · Onboarding a wallet no-custodial | — | ✅ Mergeado |
-| [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) | [@Truphile](https://github.com/Truphile) | #135 | V-5 · Confianza en el flujo de cash-in/cash-out | Nigeria (África Occidental) | ✅ Mergeado |
+| [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) | [@Truphile](https://github.com/Truphile) | #135 | V-5 · Confianza en el flujo de cash-in/cash-out | Nigeria (África Occidental) | ✅ Integrado |
 | [#143](https://github.com/ericmt-98/micopay-protocol/pull/143) | [@attyolu](https://github.com/attyolu) | #142 | V-10 · Reuso y descubrimiento de proveedores | México / LATAM | ✅ Mergeado |
 | [#145](https://github.com/ericmt-98/micopay-protocol/pull/145) | [@barnabasolutayo-lgtm](https://github.com/barnabasolutayo-lgtm) | #139 | V-7 · Alternativas actuales y switching | Monterrey MX / Bogotá CO / Buenos Aires AR / Caracas VE | ✅ Mergeado |
 | [#146](https://github.com/ericmt-98/micopay-protocol/pull/146) | [@KaruG1999](https://github.com/KaruG1999) | #138 | V-6 · Contexto de remesas y cash-out | Argentina | ✅ Mergeado |
 | [#147](https://github.com/ericmt-98/micopay-protocol/pull/147) | [@deep-bhikadiya](https://github.com/deep-bhikadiya) | #141 | V-9 · Seguridad en reunión presencial | India / Sur de Asia | ✅ Mergeado |
 | [#148](https://github.com/ericmt-98/micopay-protocol/pull/148) | [@rosemary21](https://github.com/rosemary21) | #140 | V-8 · Tolerancia a comisiones y tarifas | Nigeria (área de Lagos) | ✅ Mergeado |
 | [#169](https://github.com/ericmt-98/micopay-protocol/pull/169) | [@DevSolex](https://github.com/DevSolex) | #133 | V-3 · Perspectiva del proveedor de liquidez | Nigeria (África Occidental) | ✅ Mergeado |
-| [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) | [@Jo-anny](https://github.com/Jo-anny) | #166 | V-13 · Contexto del remitente — envío al exterior | Europa → América Latina | ✅ Mergeado |
+| [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) | [@Jo-anny](https://github.com/Jo-anny) | #166 | V-13 · Contexto del remitente — envío al exterior | Europa → América Latina | ✅ Integrado |
 | [#173](https://github.com/ericmt-98/micopay-protocol/pull/173) | [@Oluwasuyi-Timilehin](https://github.com/Oluwasuyi-Timilehin) | #165 | V-12 · Vida sin cuenta bancaria — gestión diaria de efectivo | México (CDMX) | ✅ Mergeado |
-| [#170](https://github.com/ericmt-98/micopay-protocol/pull/170) | [@Max-Owolabi](https://github.com/Max-Owolabi) | #167 | V-14 · Validación: modelo mental de stablecoin y peso digital | Nigeria (África Occidental) | ✅ Mergeado |
+| [#175](https://github.com/ericmt-98/micopay-protocol/pull/175) | [@Max-Owolabi](https://github.com/Max-Owolabi) | #167 | V-14 · Validación: modelo mental de stablecoin y peso digital | Nigeria (África Occidental) | ✅ Integrado |
+| [#174](https://github.com/ericmt-98/micopay-protocol/pull/174) | [@Chigybillionz](https://github.com/Chigybillionz) | #164 | V-11 · Transacción fallida / disputa y recuperación | Nigeria (África Occidental) | ✅ Integrado |
 
-**Total de respuestas: N=16** (V-1, V-2, V-3, V-4, V-5, V-12, V-13, V-14 en primera persona + 1 lote multi-respondente en V-10 + 3 primera persona V-6/V-8/V-9 + 3 implícitas en el lote de V-7)
-**Regiones representadas:** Nigeria (×5), México (×2), Colombia, Argentina, Venezuela, India, Europa
+**Total de respuestas: N=17** (V-1, V-2, V-3, V-4, V-5, V-11, V-12, V-13, V-14 en primera persona + 1 lote multi-respondente en V-10 + 3 primera persona V-6/V-8/V-9 + 3 implícitas en el lote de V-7)
+**Regiones representadas:** Nigeria (×6), México (×2), Colombia, Argentina, Venezuela, India, Europa
 
 ---
 
@@ -43,10 +44,10 @@ Cada contribución avanza uno o más de los cinco argumentos de nuestra narrativ
 | **1. Existe demanda** (la gente necesita convertir efectivo ↔ digital) | V-1, V-2, V-6 | V-1 ✅ (larryjay007) · V-2 ✅ (Truphile) · V-6 ✅ (KaruG1999) | Cubierto por completo (3 respuestas) |
 | **2. Existe oferta** (proveedores darían efectivo por una comisión) | V-3 | V-3 ✅ (DevSolex) | Cubierto — proveedor individual en Nigeria |
 | **3. MicoPay puede ganar** (mejor que las alternativas actuales, a una tarifa aceptable) | V-7, V-8 | V-7 ✅ (barnabasolutayo-lgtm) · V-8 ✅ (rosemary21) | Ambos cubiertos |
-| **4. Stellar es usable** (usuarios normales pueden manejar wallets no-custodiales) | V-4 | V-4 ✅ (Shadow-MMN) | Cubierto |
-| **5. Confianza y PMF** (usuarios se sienten seguros, regresarían y recomendarían) | V-5, V-9, V-10 | V-5 ✅ (Truphile) · V-9 ✅ (deep-bhikadiya) · V-10 ✅ (attyolu) | Cubierto por completo (3 respuestas) |
+| **4. Stellar es usable** (usuarios normales pueden manejar wallets no-custodiales) | V-4, V-14 | V-4 ✅ (Shadow-MMN) · V-14 ✅ (Max-Owolabi) | Cubierto (2 respuestas) |
+| **5. Confianza y PMF** (usuarios se sienten seguros, regresarían y recomendarían) | V-5, V-9, V-10, V-11 | V-5 ✅ (Truphile) · V-9 ✅ (deep-bhikadiya) · V-10 ✅ (attyolu) · V-11 ✅ (Chigybillionz) | Cubierto por completo (4 respuestas) |
 
-> **Los 5 argumentos SDF tienen cobertura.** La brecha de la oferta (V-3) fue cerrada por DevSolex. Los issues de validación abiertos (V-11, V-12, V-14, V-15) fortalecen el deck pero no son bloqueantes para el caso de financiamiento.
+> **Los 5 argumentos SDF tienen cobertura.** La brecha de la oferta (V-3) fue cerrada por DevSolex. El único issue de validación abierto es **V-15** (umbral de confianza de primera vez); fortalece el deck pero no es bloqueante para el caso de financiamiento.
 
 ---
 
@@ -306,6 +307,25 @@ Cada contribución avanza uno o más de los cinco argumentos de nuestra narrativ
 
 ---
 
+### V-11 · Transacción fallida / disputa y recuperación
+**Contribuidor:** [@Chigybillionz](https://github.com/Chigybillionz) · **PR:** [#174](https://github.com/ericmt-98/micopay-protocol/pull/174) · **Integrado:** 2026-06-27
+
+**Formato:** Primera persona, respondente único.
+
+**Región:** Nigeria (África Occidental)
+
+**Hallazgos principales:**
+
+- **La falla:** Una transferencia banco-a-banco falló en el último paso — justo después de ingresar el OTP correcto — devolviendo solo un error genérico "failed" sin explicación.
+- **Ruta de recuperación:** Sin recuperación in-app. El respondente recurrió a su red informal (un familiar le envió efectivo) para completar la compra original.
+- **Tiempo de resolución:** Más de una semana y aún sin resolver; la única ruta de escalamiento es visitar la sucursal física, que aún no había ocurrido.
+- **Qué faltó:** Dos brechas concretas de producto — (1) un estado/explicación inmediato y en lenguaje claro tras el punto de falla, y (2) soporte accesible que no exija ir a una sucursal.
+- **Impacto en comportamiento:** Erosionó la confianza en la fiabilidad de las transferencias del banco ("puede fallar en cualquier punto, incluso en el paso final"), aunque no lo suficiente para cambiar de banco — porque cambiar es de por sí de alta fricción.
+
+**Aporte a la narrativa SDF:** Afina el Argumento 5 (Confianza / PMF) desde el ángulo de la falla. Refuerza el hallazgo de V-2/V-5 de que el momento de la falla es el killer de confianza — pero añade la dimensión *posterior* a la falla: una explicación clara de estado y una ruta de soporte/disputa sin sucursal son requisitos de producto, no extras. El escrow + estado in-app + ruta de disputa visible de MicoPay responden directamente a este dolor.
+
+---
+
 ## Conclusiones transversales (para el deck ante la SDF)
 
 ### 1. El techo de tarifa es universal: 2–5%
@@ -336,15 +356,16 @@ Las respuestas ya abarcan 6+ países en 3 continentes (LATAM, Sur de Asia, Áfri
 | Issue | Asignado a | PR | Estado |
 |-------|-----------|----|-----------------------------|
 | V-1 · Demanda de cash-out | [@larryjay007](https://github.com/larryjay007) | [#155](https://github.com/ericmt-98/micopay-protocol/pull/155) ✅ | Mergeado — Nigeria (Sur Oeste) |
-| V-2 · Contexto de cash-in / depósito | [@Truphile](https://github.com/Truphile) | [#159](https://github.com/ericmt-98/micopay-protocol/pull/159) ✅ | Mergeado — Nigeria (África Occidental) |
+| V-2 · Contexto de cash-in / depósito | [@Truphile](https://github.com/Truphile) | [#159](https://github.com/ericmt-98/micopay-protocol/pull/159) ✅ | Integrado — Nigeria (África Occidental) |
 | V-3 · Perspectiva del proveedor de liquidez | [@DevSolex](https://github.com/DevSolex) | [#169](https://github.com/ericmt-98/micopay-protocol/pull/169) ✅ | Mergeado — Nigeria (África Occidental) |
 | V-4 · Onboarding a wallet no-custodial | [@Shadow-MMN](https://github.com/Shadow-MMN) | [#157](https://github.com/ericmt-98/micopay-protocol/pull/157) ✅ | Mergeado |
-| V-5 · Confianza en el flujo | [@Truphile](https://github.com/Truphile) | [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) ✅ | Mergeado — Nigeria (África Occidental) |
+| V-5 · Confianza en el flujo | [@Truphile](https://github.com/Truphile) | [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) ✅ | Integrado — Nigeria (África Occidental) |
+| V-11 · Transacción fallida / disputa | [@Chigybillionz](https://github.com/Chigybillionz) | [#174](https://github.com/ericmt-98/micopay-protocol/pull/174) ✅ | Integrado — Nigeria (África Occidental) |
 | V-12 · Vida sin cuenta bancaria | [@Oluwasuyi-Timilehin](https://github.com/Oluwasuyi-Timilehin) | [#173](https://github.com/ericmt-98/micopay-protocol/pull/173) ✅ | Mergeado — México (CDMX) |
-| V-13 · Contexto del remitente | [@Jo-anny](https://github.com/Jo-anny) | [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) ✅ | Mergeado — Europa → LATAM |
-| V-14 · Modelo mental de stablecoin | [@Max-Owolabi](https://github.com/Max-Owolabi) | [#170](https://github.com/ericmt-98/micopay-protocol/pull/170) ✅ | Mergeado — Nigeria (África Occidental) |
+| V-13 · Contexto del remitente | [@Jo-anny](https://github.com/Jo-anny) | [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) ✅ | Integrado — Europa → LATAM |
+| V-14 · Modelo mental de stablecoin | [@Max-Owolabi](https://github.com/Max-Owolabi) | [#175](https://github.com/ericmt-98/micopay-protocol/pull/175) ✅ | Integrado — Nigeria (África Occidental) |
 
-> Los 5 argumentos SDF tienen cobertura. Issues abiertos: V-11, V-15.
+> Los 5 argumentos SDF tienen cobertura. Único issue abierto: V-15 (umbral de confianza de primera vez).
 
 ---
 

--- a/docs/WAVE6_CONTRIBUTORS_REPORT_ES.md
+++ b/docs/WAVE6_CONTRIBUTORS_REPORT_ES.md
@@ -15,14 +15,18 @@
 
 | PR | Usuario de GitHub | Issue cerrado | Tema validado | Región | Estado |
 |----|-------------------|--------------|--------------|--------|--------|
+| [#155](https://github.com/ericmt-98/micopay-protocol/pull/155) | [@larryjay007](https://github.com/larryjay007) | #131 | V-1 · Contexto de cash-out | Nigeria (Sur Oeste) | ✅ Mergeado |
+| [#159](https://github.com/ericmt-98/micopay-protocol/pull/159) | [@Truphile](https://github.com/Truphile) | #132 | V-2 · Contexto de cash-in / depósito | Nigeria (África Occidental) | ✅ Mergeado |
+| [#157](https://github.com/ericmt-98/micopay-protocol/pull/157) | [@Shadow-MMN](https://github.com/Shadow-MMN) | #134 | V-4 · Onboarding a wallet no-custodial | — | ✅ Mergeado |
+| [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) | [@Truphile](https://github.com/Truphile) | #135 | V-5 · Confianza en el flujo de cash-in/cash-out | Nigeria (África Occidental) | ✅ Mergeado |
 | [#143](https://github.com/ericmt-98/micopay-protocol/pull/143) | [@attyolu](https://github.com/attyolu) | #142 | V-10 · Reuso y descubrimiento de proveedores | México / LATAM | ✅ Mergeado |
 | [#145](https://github.com/ericmt-98/micopay-protocol/pull/145) | [@barnabasolutayo-lgtm](https://github.com/barnabasolutayo-lgtm) | #139 | V-7 · Alternativas actuales y switching | Monterrey MX / Bogotá CO / Buenos Aires AR / Caracas VE | ✅ Mergeado |
 | [#146](https://github.com/ericmt-98/micopay-protocol/pull/146) | [@KaruG1999](https://github.com/KaruG1999) | #138 | V-6 · Contexto de remesas y cash-out | Argentina | ✅ Mergeado |
 | [#147](https://github.com/ericmt-98/micopay-protocol/pull/147) | [@deep-bhikadiya](https://github.com/deep-bhikadiya) | #141 | V-9 · Seguridad en reunión presencial | India / Sur de Asia | ✅ Mergeado |
 | [#148](https://github.com/ericmt-98/micopay-protocol/pull/148) | [@rosemary21](https://github.com/rosemary21) | #140 | V-8 · Tolerancia a comisiones y tarifas | Nigeria (área de Lagos) | ✅ Mergeado |
 
-**Total de respuestas hasta ahora: N=8** (1 lote multi-respondente en V-10 + 4 respuestas en primera persona + 3 implícitas en el lote de V-7)
-**Regiones representadas:** México, Colombia, Argentina, Venezuela, India, Nigeria
+**Total de respuestas: N=12** (V-1, V-2, V-4, V-5 en primera persona + 1 lote multi-respondente en V-10 + 4 primera persona V-6/V-8/V-9 + 3 implícitas en el lote de V-7)
+**Regiones representadas:** Nigeria (×3), México, Colombia, Argentina, Venezuela, India
 
 ---
 
@@ -32,17 +36,91 @@ Cada contribución avanza uno o más de los cinco argumentos de nuestra narrativ
 
 | Argumento SDF | Issues que lo respaldan | Respuestas recibidas | Faltante |
 |---------------|------------------------|---------------------|----------|
-| **1. Existe demanda** (la gente necesita convertir efectivo ↔ digital) | V-1, V-2, V-6 | V-6 ✅ (KaruG1999) | V-1 y V-2 aún sin respuesta |
-| **2. Existe oferta** (proveedores darían efectivo por una comisión) | V-3 | Ninguna aún | V-3 sin asignar |
+| **1. Existe demanda** (la gente necesita convertir efectivo ↔ digital) | V-1, V-2, V-6 | V-1 ✅ (larryjay007) · V-2 ✅ (Truphile) · V-6 ✅ (KaruG1999) | Cubierto por completo (3 respuestas) |
+| **2. Existe oferta** (proveedores darían efectivo por una comisión) | V-3 | Ninguna aún | V-3 sin asignar — **🔴 brecha crítica** |
 | **3. MicoPay puede ganar** (mejor que las alternativas actuales, a una tarifa aceptable) | V-7, V-8 | V-7 ✅ (barnabasolutayo-lgtm) · V-8 ✅ (rosemary21) | Ambos cubiertos |
-| **4. Stellar es usable** (usuarios normales pueden manejar wallets no-custodiales) | V-4 | Ninguna aún | V-4 asignado a @Shadow-MMN, sin PR |
-| **5. Confianza y PMF** (usuarios se sienten seguros, regresarían y recomendarían) | V-5, V-9, V-10 | V-9 ✅ (deep-bhikadiya) · V-10 ✅ (attyolu) | V-5 asignado a @Truphile, sin PR |
+| **4. Stellar es usable** (usuarios normales pueden manejar wallets no-custodiales) | V-4 | V-4 ✅ (Shadow-MMN) | Cubierto |
+| **5. Confianza y PMF** (usuarios se sienten seguros, regresarían y recomendarían) | V-5, V-9, V-10 | V-5 ✅ (Truphile) · V-9 ✅ (deep-bhikadiya) · V-10 ✅ (attyolu) | Cubierto por completo (3 respuestas) |
 
-> **Prioridad urgente:** V-1 (demanda de cash-out) y V-3 (oferta de liquidez) — los dos lados centrales del mercado. Sin al menos una respuesta por cada uno, el caso de financiamiento no tiene base.
+> **Única brecha restante:** V-3 (perspectiva del proveedor de liquidez) — el lado de la oferta del mercado. Sin una perspectiva en primera persona del proveedor, el argumento de oferta ante la SDF queda sin sustento.
 
 ---
 
 ## Entradas detalladas por contribuidor
+
+---
+
+### V-1 · Contexto de cash-out
+**Contribuidor:** [@larryjay007](https://github.com/larryjay007) · **PR:** [#155](https://github.com/ericmt-98/micopay-protocol/pull/155) · **Mergeado:** 2026-06-25
+
+**Formato:** Primera persona, respondente único.
+
+**Región:** Nigeria (Sur Oeste)
+
+**Hallazgos principales:**
+
+- **Frecuencia de cash-out:** Semanal — una necesidad recurrente, no ocasional.
+- **Método actual:** Intercambio P2P o transferencia bancaria a cuenta local, seguido de retiro en cajero o a través de un agente POS.
+- **Fricción principal:** Fees acumulados altos, cajeros sin disponibilidad confiable y límites de retiro diarios.
+- **Experiencia vivida:** Más de una hora visitando tres sucursales bancarias por cajeros vacíos y fallas de red. Al encontrar finalmente un cajero funcional, el límite de retiro obligó a hacer múltiples transacciones con cargos adicionales.
+
+**Aporte a la narrativa SDF:** Incorpora Nigeria (Sur Oeste) a la señal de demanda de cash-out para el Argumento 1. Frecuencia semanal + fallas de cajeros + límites de retiro = dolor recurrente fuerte que una red de agentes P2P local resuelve directamente.
+
+---
+
+### V-2 · Contexto de cash-in / depósito
+**Contribuidor:** [@Truphile](https://github.com/Truphile) · **PR:** [#159](https://github.com/ericmt-98/micopay-protocol/pull/159) · **Mergeado:** 2026-06-25
+
+**Formato:** Primera persona, respondente único.
+
+**Región:** Nigeria (África Occidental)
+
+**Hallazgos principales:**
+
+- **Por qué importa el cash-in:** Cobrar en efectivo por trabajos informales o de amigos hace imposible pagar facturas digitales (AWS, tokens de servicios, bolsillos de ahorro fintech). Cash-in = puerta de entrada a la economía digital.
+- **Método actual:** Acudir a un agente PoS del barrio, entregar el efectivo físico, proporcionar los datos de cuenta y esperar la transferencia a la wallet via la terminal del agente.
+- **Frecuencia:** Varias veces al mes — siempre que el efectivo físico se acumula.
+- **Principal barrera de confianza:** Fallas de red mid-transacción. El miedo a entregar el dinero y escuchar "la red está mala, el dinero aún no ha llegado." Una reversión puede tardar 24–48 horas.
+- **Proveedores locales de confianza:** Sí — kioscos de marca establecida y ubicación física permanente. La responsabilidad reputacional los hace confiables.
+
+**Aporte a la narrativa SDF:** Confirma la demanda bidireccional (Argumento 1) desde África Occidental. El riesgo clave de UX a resolver: la falla de red en el momento de la transacción de efectivo debe tener una solución inmediata de estado in-app.
+
+---
+
+### V-4 · Onboarding a wallet no-custodial
+**Contribuidor:** [@Shadow-MMN](https://github.com/Shadow-MMN) · **PR:** [#157](https://github.com/ericmt-98/micopay-protocol/pull/157) · **Mergeado:** 2026-06-25
+
+**Formato:** Auditoría UX en primera persona de la app actual de MicoPay.
+
+**Hallazgos principales:**
+
+- **Claridad sobre custodia de la llave:** Nada claro. No existe pantalla de onboarding — el keypair se generó en silencio, solo detectable inspeccionando el localStorage del navegador.
+- **Mayor miedo:** Perder la llave a un hacker, ya que está almacenada en localStorage sin protección visible para el usuario.
+- **Mínimo para generar confianza:** Una pantalla dedicada al primer inicio explicando que se creó una wallet, mostrando la llave pública y promoviendo el respaldo de la llave secreta.
+- **Crear vs importar:** Preferencia por importar una llave Stellar existente — el usuario ya tiene fondos y no quiere la fricción de moverlos entre wallets.
+- **Respaldo obligatorio vs opcional:** Opcional, pero la UI debe hacerlo trivialmente fácil (un toque para copiar + nota de seguridad prominente). El respaldo obligatorio frustra a quienes quieren probar la app; el respaldo invisible frustra a los usuarios serios.
+
+**Aporte a la narrativa SDF:** Primera auditoría UX directa del flujo de onboarding para el Argumento 4 (Stellar es usable). El veredicto es claro: la app actual no cumple el mínimo para un usuario no técnico. Los hallazgos dan al equipo una lista accionable: pantalla de onboarding → visualización de la llave → flujo de copia-para-respaldo.
+
+---
+
+### V-5 · Confianza en el flujo de cash-in/cash-out
+**Contribuidor:** [@Truphile](https://github.com/Truphile) · **PR:** [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) · **Mergeado:** 2026-06-25
+
+**Formato:** Primera persona, respondente único.
+
+**Región:** Nigeria (África Occidental)
+
+**Hallazgos principales:**
+
+- **Tipo de proveedor más confiable:** Un kiosco PoS de marca establecida y permanente, con flujo constante de clientes y terminal Android dedicada.
+- **Menos confiable:** Un agente móvil sin marca en una esquina con solo un teléfono, o uno que dice "la red está mala" antes de intentar la transacción.
+- **Información mínima antes de entregar efectivo:** (1) Fee exacto declarado de antemano · (2) Valor final bloqueado que se reflejará en la wallet · (3) Confirmación clara en pantalla de que el sistema del agente está activo y en línea.
+- **Señales de verificación necesarias:** La ubicación y nombre del agente coincidiendo exactamente con lo que aparece en el mapa in-app + insignia de "Agente de Confianza" o indicador de alta tasa de completitud.
+- **Expectativa de soporte en caso de falla:** SMS automático inmediato o estado in-app "Pendiente / Dinero Recibido" · canal de WhatsApp o línea gratuita para resolver transacciones colgadas en minutos.
+- **Causa principal de abandono:** Cualquier demora en el momento del pago — "la red está fluctuando" o generación lenta del QR/recibo dispara el miedo a fondos atrapados.
+
+**Aporte a la narrativa SDF:** Mapea las señales de confianza y abandono directamente al Argumento 5 (Confianza / PMF). La lista de tres puntos — tarifa transparente, tasa bloqueada, estado en línea — es un requisito concreto de UX que el flujo del agente debe satisfacer antes de que el efectivo cambie de manos. Combinado con V-2, construye el panorama completo de confianza en Nigeria.
 
 ---
 
@@ -152,16 +230,22 @@ Cada contribución avanza uno o más de los cinco argumentos de nuestra narrativ
 En Nigeria, Venezuela, México, Colombia y Argentina, los respondentes convergen de forma independiente en el mismo rango. Más del 5% pierde frente al canal tradicional — incluso para personas con acceso muy limitado. Esto le da a MicoPay una restricción de precios concreta y defendible.
 
 ### 2. La confianza no es opcional — es el producto
-Cada respondente, en cada tema, mencionó las señales de confianza como prerequisito: perfiles verificados, calificaciones, chat in-app, recibos, acceso a soporte. No es un "nice to have" de UX — es la propuesta de valor central del producto, a la par de las tarifas bajas.
+Cada respondente, en cada tema, mencionó las señales de confianza como prerequisito: perfiles verificados, calificaciones, chat in-app, recibos, acceso a soporte. No es un "nice to have" de UX — es la propuesta de valor central del producto, a la par de las tarifas bajas. V-5 (Truphile) da la articulación más precisa: tres señales no negociables deben aparecer antes de que el efectivo cambie de manos — tarifa transparente, tasa bloqueada y confirmación de estado en línea.
 
 ### 3. La última milla es el problema real, incluso para usuarios de Stellar
 La respondente de Argentina (V-6) ya usa Stellar para transferencias transfronterizas y aun así no puede obtener efectivo localmente sin riesgo de contraparte P2P. El valor de MicoPay no está en la blockchain — está en la entrega de efectivo confiable, local y en el mismo día.
 
 ### 4. El argumento "sin cuenta bancaria" es el unlock más fuerte
-Lo nombra explícitamente Nigeria (V-8) y está implícito en Venezuela (V-7). Para África Subsahariana y las economías hiperinflacionarias de LATAM, eliminar la dependencia de la cuenta bancaria es más convincente que cualquier argumento de tarifa.
+Lo nombra explícitamente Nigeria (V-8) y está implícito en Venezuela (V-7) y confirmado por V-2 (Truphile): el cash-in digital es la puerta de entrada a la economía digital para personas cuyo ingreso llega en papel. Para África Subsahariana y las economías hiperinflacionarias de LATAM, eliminar la dependencia de la cuenta bancaria es más convincente que cualquier argumento de tarifa.
 
-### 5. La diversidad geográfica desriesga el caso ante la SDF
-Las respuestas ya abarcan 6 países en 3 continentes (LATAM, Sur de Asia, África). La convergencia de puntos de dolor y preferencias en mercados tan distintos fortalece el argumento de que este es un problema estructural — no una particularidad local — y que la infraestructura de Stellar puede resolverlo a escala global.
+### 5. El onboarding de la wallet está roto — V-4 lo prueba
+La auditoría de Shadow-MMN (V-4) encontró que la app genera un keypair en silencio, lo almacena en localStorage sin notificar al usuario y no tiene prompt de respaldo. Esta es una brecha crítica para el Argumento 4. La solución está bien definida: pantalla de onboarding al primer inicio → visualización de llave pública → respaldo de llave secreta con un toque. Esto debe estar en producción antes de cualquier demo ante la SDF.
+
+### 6. La falla de red en el momento de entrega de efectivo es el mayor killer de confianza
+V-2 y V-5 (África Occidental) identifican de forma independiente el mismo trigger de abandono: entregar efectivo físico y escuchar "la red está mala." Esto señala un único requisito de producto de alta prioridad — el feedback de estado de la transacción en tiempo real (SMS o in-app) debe ser inmediato e inequívoco, con una ruta de resolución clara (WhatsApp / línea gratuita).
+
+### 7. La diversidad geográfica desriesga el caso ante la SDF
+Las respuestas ya abarcan 6+ países en 3 continentes (LATAM, Sur de Asia, África). La convergencia de puntos de dolor y preferencias en mercados tan distintos fortalece el argumento de que este es un problema estructural — no una particularidad local — y que la infraestructura de Stellar puede resolverlo a escala global.
 
 ---
 
@@ -185,9 +269,9 @@ Las respuestas ya abarcan 6 países en 3 continentes (LATAM, Sur de Asia, Áfric
 - **Primera persona:** cada entrada refleja la experiencia propia del contribuidor — no una encuesta a terceros.
 - **Muestra por conveniencia**, auto-seleccionada a través del programa Stellar Drips Wave 6. Señal direccional y cualitativa, no representativa estadísticamente.
 - **Privacy-first:** sin nombres, sin datos de contacto, sin montos de dinero, sin direcciones de wallet.
-- Tamaño actual de la muestra: **N=8 perspectivas individuales** en **6 países / 3 regiones**.
+- Tamaño actual de la muestra: **N=12 perspectivas individuales** en **6+ países / 3 regiones**.
 - Reportar `N` con claridad. Dejar que la consistencia de los patrones entre regiones hable por sí sola.
 
 ---
 
-*Última actualización: 2026-06-24 · Maintainer: [@ericmt-98](https://github.com/ericmt-98)*
+*Última actualización: 2026-06-25 · Maintainer: [@ericmt-98](https://github.com/ericmt-98)*

--- a/docs/WAVE6_CONTRIBUTORS_REPORT_ES.md
+++ b/docs/WAVE6_CONTRIBUTORS_REPORT_ES.md
@@ -27,9 +27,10 @@
 | [#169](https://github.com/ericmt-98/micopay-protocol/pull/169) | [@DevSolex](https://github.com/DevSolex) | #133 | V-3 · Perspectiva del proveedor de liquidez | Nigeria (África Occidental) | ✅ Mergeado |
 | [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) | [@Jo-anny](https://github.com/Jo-anny) | #166 | V-13 · Contexto del remitente — envío al exterior | Europa → América Latina | ✅ Mergeado |
 | [#173](https://github.com/ericmt-98/micopay-protocol/pull/173) | [@Oluwasuyi-Timilehin](https://github.com/Oluwasuyi-Timilehin) | #165 | V-12 · Vida sin cuenta bancaria — gestión diaria de efectivo | México (CDMX) | ✅ Mergeado |
+| [#170](https://github.com/ericmt-98/micopay-protocol/pull/170) | [@Max-Owolabi](https://github.com/Max-Owolabi) | #167 | V-14 · Validación: modelo mental de stablecoin y peso digital | Nigeria (África Occidental) | ✅ Mergeado |
 
-**Total de respuestas: N=15** (V-1, V-2, V-3, V-4, V-5, V-12, V-13 en primera persona + 1 lote multi-respondente en V-10 + 3 primera persona V-6/V-8/V-9 + 3 implícitas en el lote de V-7)
-**Regiones representadas:** Nigeria (×4), México (×2), Colombia, Argentina, Venezuela, India, Europa
+**Total de respuestas: N=16** (V-1, V-2, V-3, V-4, V-5, V-12, V-13, V-14 en primera persona + 1 lote multi-respondente en V-10 + 3 primera persona V-6/V-8/V-9 + 3 implícitas en el lote de V-7)
+**Regiones representadas:** Nigeria (×5), México (×2), Colombia, Argentina, Venezuela, India, Europa
 
 ---
 
@@ -246,6 +247,25 @@ Cada contribución avanza uno o más de los cinco argumentos de nuestra narrativ
 
 ---
 
+### V-14 · Modelo mental de stablecoin y peso digital
+**Contribuidor:** [@Max-Owolabi](https://github.com/Max-Owolabi) · **PR:** [#170](https://github.com/ericmt-98/micopay-protocol/pull/170) · **Mergeado:** 2026-06-26
+
+**Formato:** Primera persona, respondente único.
+
+**Región:** Nigeria (África Occidental)
+
+**Hallazgos principales:**
+
+- **Experiencia previa con stablecoins:** Sí — USDC y USDT en Stellar y otras redes, obtenidos via agentes de cambio locales y plataformas P2P. Usados principalmente para protegerse de la inflación de la moneda local y pagar servicios digitales donde las tarjetas locales fallan.
+- **Modelo mental vs efectivo físico:** Inicialmente abstracto ("un número en pantalla"). La confianza se construyó por: posibilidad de reconversión a fiat, utilidad de pago global, seguridad del smart contract, transparencia de transacciones on-chain.
+- **Parte más difícil de entender:** Tarifas de gas/red, diferencias multichain del mismo token (Stellar vs Ethereum), gestión de claves de autocustodia sin soporte bancario para restablecimiento de contraseña.
+- **Reacción a "tus fondos están en una wallet digital":** Curiosidad + cautela — más seguro contra robo físico, pero teme hackeo digital o pérdida de claves sin opciones claras de recuperación.
+- **Detonador de equivalencia a efectivo:** Conversión instantánea garantizada a efectivo en cualquier tienda de barrio, sin tarifas altas, y confirmación visible del escrow in-app.
+
+**Aporte a la narrativa SDF:** Valida el Argumento 4 (Stellar es usable) desde un mercado inflacionario. Las stablecoins ya son valoradas como herramienta real en África Occidental — la brecha es la conversión de la última milla a efectivo y la UX de recuperación de claves, exactamente lo que el modelo de agente local + escrow de MicoPay resuelve.
+
+---
+
 ### V-3 · Perspectiva del proveedor de liquidez
 **Contribuidor:** [@DevSolex](https://github.com/DevSolex) · **PR:** [#169](https://github.com/ericmt-98/micopay-protocol/pull/169) · **Mergeado:** 2026-06-26
 
@@ -322,8 +342,9 @@ Las respuestas ya abarcan 6+ países en 3 continentes (LATAM, Sur de Asia, Áfri
 | V-5 · Confianza en el flujo | [@Truphile](https://github.com/Truphile) | [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) ✅ | Mergeado — Nigeria (África Occidental) |
 | V-12 · Vida sin cuenta bancaria | [@Oluwasuyi-Timilehin](https://github.com/Oluwasuyi-Timilehin) | [#173](https://github.com/ericmt-98/micopay-protocol/pull/173) ✅ | Mergeado — México (CDMX) |
 | V-13 · Contexto del remitente | [@Jo-anny](https://github.com/Jo-anny) | [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) ✅ | Mergeado — Europa → LATAM |
+| V-14 · Modelo mental de stablecoin | [@Max-Owolabi](https://github.com/Max-Owolabi) | [#170](https://github.com/ericmt-98/micopay-protocol/pull/170) ✅ | Mergeado — Nigeria (África Occidental) |
 
-> Los 5 argumentos SDF tienen cobertura. Issues abiertos: V-11, V-14, V-15.
+> Los 5 argumentos SDF tienen cobertura. Issues abiertos: V-11, V-15.
 
 ---
 
@@ -332,7 +353,7 @@ Las respuestas ya abarcan 6+ países en 3 continentes (LATAM, Sur de Asia, Áfri
 - **Primera persona:** cada entrada refleja la experiencia propia del contribuidor — no una encuesta a terceros.
 - **Muestra por conveniencia**, auto-seleccionada a través del programa Stellar Drips Wave 6. Señal direccional y cualitativa, no representativa estadísticamente.
 - **Privacy-first:** sin nombres, sin datos de contacto, sin montos de dinero, sin direcciones de wallet.
-- Tamaño actual de la muestra: **N=15 perspectivas individuales** en **7+ países / 3 regiones**.
+- Tamaño actual de la muestra: **N=16 perspectivas individuales** en **7+ países / 3 regiones**.
 - Reportar `N` con claridad. Dejar que la consistencia de los patrones entre regiones hable por sí sola.
 
 ---

--- a/docs/WAVE6_CONTRIBUTORS_REPORT_ES.md
+++ b/docs/WAVE6_CONTRIBUTORS_REPORT_ES.md
@@ -167,17 +167,16 @@ Las respuestas ya abarcan 6 países en 3 continentes (LATAM, Sur de Asia, Áfric
 
 ## Qué falta
 
-| Issue | Asignado a | PR | Prioridad para el caso SDF |
+| Issue | Asignado a | PR | Estado |
 |-------|-----------|----|-----------------------------|
-| V-1 · Demanda de cash-out | [@larryjay007](https://github.com/larryjay007) | Sin PR aún | 🔴 Crítico — señal central de demanda |
-| V-2 · Contexto de cash-in / depósito | [@Truphile](https://github.com/Truphile) | Sin PR aún | 🔴 Crítico — demanda bidireccional |
+| V-1 · Demanda de cash-out | [@larryjay007](https://github.com/larryjay007) | [#155](https://github.com/ericmt-98/micopay-protocol/pull/155) ✅ | Mergeado — Nigeria (Sur Oeste) |
+| V-2 · Contexto de cash-in / depósito | [@Truphile](https://github.com/Truphile) | [#159](https://github.com/ericmt-98/micopay-protocol/pull/159) ✅ | Mergeado — Nigeria (África Occidental) |
 | V-3 · Perspectiva del proveedor de liquidez | [@3m1n3nc3](https://github.com/3m1n3nc3) | Sin PR aún | 🔴 Crítico — lado de la oferta del mercado |
-| V-4 · Onboarding a wallet no-custodial | [@Shadow-MMN](https://github.com/Shadow-MMN) | Sin PR aún | 🟡 Importante — argumento de usabilidad de Stellar |
-| V-5 · Confianza en el flujo | [@Truphile](https://github.com/Truphile) | Sin PR aún | 🟡 Importante — PMF y riesgo de abandono |
+| V-4 · Onboarding a wallet no-custodial | [@Shadow-MMN](https://github.com/Shadow-MMN) | [#157](https://github.com/ericmt-98/micopay-protocol/pull/157) ✅ | Mergeado |
+| V-5 · Confianza en el flujo | [@Truphile](https://github.com/Truphile) | [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) ✅ | Mergeado — Nigeria (África Occidental) |
 
-> V-1, V-2 y V-3 son la prioridad más alta. Sin al menos una respuesta en primera persona para cada uno,
-> la narrativa ante la SDF carece de sus dos argumentos más fundamentales: que la gente necesita esto
-> (demanda) y que alguien lo proveería (oferta).
+> V-3 es la brecha crítica restante. Sin una perspectiva en primera persona del proveedor de liquidez,
+> el lado de la oferta de la narrativa ante la SDF queda sin sustento.
 
 ---
 

--- a/docs/WAVE6_CONTRIBUTORS_REPORT_ES.md
+++ b/docs/WAVE6_CONTRIBUTORS_REPORT_ES.md
@@ -24,9 +24,11 @@
 | [#146](https://github.com/ericmt-98/micopay-protocol/pull/146) | [@KaruG1999](https://github.com/KaruG1999) | #138 | V-6 · Contexto de remesas y cash-out | Argentina | ✅ Mergeado |
 | [#147](https://github.com/ericmt-98/micopay-protocol/pull/147) | [@deep-bhikadiya](https://github.com/deep-bhikadiya) | #141 | V-9 · Seguridad en reunión presencial | India / Sur de Asia | ✅ Mergeado |
 | [#148](https://github.com/ericmt-98/micopay-protocol/pull/148) | [@rosemary21](https://github.com/rosemary21) | #140 | V-8 · Tolerancia a comisiones y tarifas | Nigeria (área de Lagos) | ✅ Mergeado |
+| [#169](https://github.com/ericmt-98/micopay-protocol/pull/169) | [@DevSolex](https://github.com/DevSolex) | #133 | V-3 · Perspectiva del proveedor de liquidez | Nigeria (África Occidental) | ✅ Mergeado |
+| [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) | [@Jo-anny](https://github.com/Jo-anny) | #166 | V-13 · Contexto del remitente — envío al exterior | Europa → América Latina | ✅ Mergeado |
 
-**Total de respuestas: N=12** (V-1, V-2, V-4, V-5 en primera persona + 1 lote multi-respondente en V-10 + 4 primera persona V-6/V-8/V-9 + 3 implícitas en el lote de V-7)
-**Regiones representadas:** Nigeria (×3), México, Colombia, Argentina, Venezuela, India
+**Total de respuestas: N=14** (V-1, V-2, V-3, V-4, V-5, V-13 en primera persona + 1 lote multi-respondente en V-10 + 3 primera persona V-6/V-8/V-9 + 3 implícitas en el lote de V-7)
+**Regiones representadas:** Nigeria (×4), México, Colombia, Argentina, Venezuela, India, Europa
 
 ---
 
@@ -37,12 +39,12 @@ Cada contribución avanza uno o más de los cinco argumentos de nuestra narrativ
 | Argumento SDF | Issues que lo respaldan | Respuestas recibidas | Faltante |
 |---------------|------------------------|---------------------|----------|
 | **1. Existe demanda** (la gente necesita convertir efectivo ↔ digital) | V-1, V-2, V-6 | V-1 ✅ (larryjay007) · V-2 ✅ (Truphile) · V-6 ✅ (KaruG1999) | Cubierto por completo (3 respuestas) |
-| **2. Existe oferta** (proveedores darían efectivo por una comisión) | V-3 | Ninguna aún | V-3 sin asignar — **🔴 brecha crítica** |
+| **2. Existe oferta** (proveedores darían efectivo por una comisión) | V-3 | V-3 ✅ (DevSolex) | Cubierto — proveedor individual en Nigeria |
 | **3. MicoPay puede ganar** (mejor que las alternativas actuales, a una tarifa aceptable) | V-7, V-8 | V-7 ✅ (barnabasolutayo-lgtm) · V-8 ✅ (rosemary21) | Ambos cubiertos |
 | **4. Stellar es usable** (usuarios normales pueden manejar wallets no-custodiales) | V-4 | V-4 ✅ (Shadow-MMN) | Cubierto |
 | **5. Confianza y PMF** (usuarios se sienten seguros, regresarían y recomendarían) | V-5, V-9, V-10 | V-5 ✅ (Truphile) · V-9 ✅ (deep-bhikadiya) · V-10 ✅ (attyolu) | Cubierto por completo (3 respuestas) |
 
-> **Única brecha restante:** V-3 (perspectiva del proveedor de liquidez) — el lado de la oferta del mercado. Sin una perspectiva en primera persona del proveedor, el argumento de oferta ante la SDF queda sin sustento.
+> **Los 5 argumentos SDF tienen cobertura.** La brecha de la oferta (V-3) fue cerrada por DevSolex. Los issues de validación abiertos (V-11, V-12, V-14, V-15) fortalecen el deck pero no son bloqueantes para el caso de financiamiento.
 
 ---
 
@@ -224,6 +226,46 @@ Cada contribución avanza uno o más de los cinco argumentos de nuestra narrativ
 
 ---
 
+### V-3 · Perspectiva del proveedor de liquidez
+**Contribuidor:** [@DevSolex](https://github.com/DevSolex) · **PR:** [#169](https://github.com/ericmt-98/micopay-protocol/pull/169) · **Mergeado:** 2026-06-26
+
+**Formato:** Primera persona, respondente único.
+
+**Región:** Nigeria (África Occidental)
+
+**Hallazgos principales:**
+
+- **¿Proveería liquidez?** Sí — con condiciones: el escrow debe bloquear los fondos antes de entregar el efectivo.
+- **Tipo de proveedor:** Individual con actividad informal paralela; maneja flujos de efectivo modestos y hace intercambios P2P ocasionales en su círculo local.
+- **Motivación principal:** Ingresos por comisión + conveniencia de convertir stablecoins ya en posesión a moneda local sin pasar por el banco. También genera reputación local.
+- **Riesgos percibidos:** No pago o transferencia digital falsa/reversada; seguridad física al llevar o entregar efectivo en público; ambigüedad regulatoria; falta de ruta de resolución de disputas.
+- **Comisión esperada:** 2–3%. Menos del 2% no cubre el tiempo y el riesgo de liquidez; más del 4% devuelve a los usuarios a los canales informales.
+- **Detonador de confianza:** Ver el USDC bloqueado en escrow *antes* de entregar cualquier efectivo — esa única garantía elimina la mayor parte del riesgo.
+
+**Aporte a la narrativa SDF:** Cierra la brecha del lado de la oferta para el Argumento 2. Confirma voluntad real de proveer liquidez entre cambiadores P2P informales en África Occidental, y fija el rango de comisión en 2–3% — consistente con la ventana de 1–5% de V-8. El requisito de diseño más claro: el bloqueo del escrow debe ser visible para el proveedor antes de que mueva cualquier efectivo.
+
+---
+
+### V-13 · Contexto del remitente — envío de dinero al exterior
+**Contribuidor:** [@Jo-anny](https://github.com/Jo-anny) · **PR:** [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) · **Mergeado:** 2026-06-26
+
+**Formato:** Primera persona, respondente único.
+
+**Región:** Europa → América Latina (lado del remitente)
+
+**Hallazgos principales:**
+
+- **Método actual:** Mezcla de transferencias bancarias y servicios de remesas digitales; a veces P2P cripto para acceso más rápido del receptor.
+- **Costo:** Porcentaje de un solo dígito alto en total (fees de servicio + spread de conversión combinados).
+- **Tiempo de entrega:** Mismo día o al día siguiente normalmente; los bancos pueden tardar varios días si se activan verificaciones de compliance.
+- **Mayor frustración:** Opacidad — el monto final recibido es desconocido hasta que la transacción se liquida. El receptor además tiene que gestionar pasos separados de cash-out o disponibilidad de agentes.
+- **¿Qué haría el receptor con el dinero?** Hace cash-out a moneda local via banco, pickup en efectivo, o wallet móvil + retiro con agente.
+- **Detonador de cambio:** Más barato, rápido y transparente — y crucialmente, saber el monto final recibido y la opción de cash-out **antes** de enviar.
+
+**Aporte a la narrativa SDF:** Añade la perspectiva del remitente a la señal de demanda de remesas (Argumento 1). V-6 (Argentina) cubrió al receptor; V-13 cierra el ciclo desde el emisor. El requisito de "certeza antes de enviar" es un spec de producto directo: la pantalla de confirmación de la transacción debe mostrar el equivalente exacto en MXN y la disponibilidad de proveedores cercanos antes de que el usuario confirme.
+
+---
+
 ## Conclusiones transversales (para el deck ante la SDF)
 
 ### 1. El techo de tarifa es universal: 2–5%
@@ -255,12 +297,12 @@ Las respuestas ya abarcan 6+ países en 3 continentes (LATAM, Sur de Asia, Áfri
 |-------|-----------|----|-----------------------------|
 | V-1 · Demanda de cash-out | [@larryjay007](https://github.com/larryjay007) | [#155](https://github.com/ericmt-98/micopay-protocol/pull/155) ✅ | Mergeado — Nigeria (Sur Oeste) |
 | V-2 · Contexto de cash-in / depósito | [@Truphile](https://github.com/Truphile) | [#159](https://github.com/ericmt-98/micopay-protocol/pull/159) ✅ | Mergeado — Nigeria (África Occidental) |
-| V-3 · Perspectiva del proveedor de liquidez | [@3m1n3nc3](https://github.com/3m1n3nc3) | Sin PR aún | 🔴 Crítico — lado de la oferta del mercado |
+| V-3 · Perspectiva del proveedor de liquidez | [@DevSolex](https://github.com/DevSolex) | [#169](https://github.com/ericmt-98/micopay-protocol/pull/169) ✅ | Mergeado — Nigeria (África Occidental) |
 | V-4 · Onboarding a wallet no-custodial | [@Shadow-MMN](https://github.com/Shadow-MMN) | [#157](https://github.com/ericmt-98/micopay-protocol/pull/157) ✅ | Mergeado |
 | V-5 · Confianza en el flujo | [@Truphile](https://github.com/Truphile) | [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) ✅ | Mergeado — Nigeria (África Occidental) |
+| V-13 · Contexto del remitente | [@Jo-anny](https://github.com/Jo-anny) | [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) ✅ | Mergeado — Europa → LATAM |
 
-> V-3 es la brecha crítica restante. Sin una perspectiva en primera persona del proveedor de liquidez,
-> el lado de la oferta de la narrativa ante la SDF queda sin sustento.
+> Los 5 argumentos SDF tienen cobertura. Issues abiertos: V-11, V-12, V-14, V-15.
 
 ---
 
@@ -269,9 +311,9 @@ Las respuestas ya abarcan 6+ países en 3 continentes (LATAM, Sur de Asia, Áfri
 - **Primera persona:** cada entrada refleja la experiencia propia del contribuidor — no una encuesta a terceros.
 - **Muestra por conveniencia**, auto-seleccionada a través del programa Stellar Drips Wave 6. Señal direccional y cualitativa, no representativa estadísticamente.
 - **Privacy-first:** sin nombres, sin datos de contacto, sin montos de dinero, sin direcciones de wallet.
-- Tamaño actual de la muestra: **N=12 perspectivas individuales** en **6+ países / 3 regiones**.
+- Tamaño actual de la muestra: **N=14 perspectivas individuales** en **7+ países / 3 regiones**.
 - Reportar `N` con claridad. Dejar que la consistencia de los patrones entre regiones hable por sí sola.
 
 ---
 
-*Última actualización: 2026-06-25 · Maintainer: [@ericmt-98](https://github.com/ericmt-98)*
+*Última actualización: 2026-06-26 · Maintainer: [@ericmt-98](https://github.com/ericmt-98)*

--- a/docs/WAVE6_CONTRIBUTORS_REPORT_ES.md
+++ b/docs/WAVE6_CONTRIBUTORS_REPORT_ES.md
@@ -170,8 +170,8 @@ Las respuestas ya abarcan 6 países en 3 continentes (LATAM, Sur de Asia, Áfric
 | Issue | Asignado a | PR | Prioridad para el caso SDF |
 |-------|-----------|----|-----------------------------|
 | V-1 · Demanda de cash-out | [@larryjay007](https://github.com/larryjay007) | Sin PR aún | 🔴 Crítico — señal central de demanda |
-| V-2 · Contexto de cash-in / depósito | Sin asignar | Sin PR aún | 🔴 Crítico — demanda bidireccional |
-| V-3 · Perspectiva del proveedor de liquidez | Sin asignar | Sin PR aún | 🔴 Crítico — lado de la oferta del mercado |
+| V-2 · Contexto de cash-in / depósito | [@Truphile](https://github.com/Truphile) | Sin PR aún | 🔴 Crítico — demanda bidireccional |
+| V-3 · Perspectiva del proveedor de liquidez | [@3m1n3nc3](https://github.com/3m1n3nc3) | Sin PR aún | 🔴 Crítico — lado de la oferta del mercado |
 | V-4 · Onboarding a wallet no-custodial | [@Shadow-MMN](https://github.com/Shadow-MMN) | Sin PR aún | 🟡 Importante — argumento de usabilidad de Stellar |
 | V-5 · Confianza en el flujo | [@Truphile](https://github.com/Truphile) | Sin PR aún | 🟡 Importante — PMF y riesgo de abandono |
 

--- a/docs/WAVE6_RESEARCH_ISSUES.md
+++ b/docs/WAVE6_RESEARCH_ISSUES.md
@@ -43,7 +43,7 @@
 | V-11 | [#164](https://github.com/ericmt-98/micopay-protocol/issues/164) | Failed transaction / dispute | Trust recovery after failure | 🆕 Open |
 | V-12 | [#165](https://github.com/ericmt-98/micopay-protocol/issues/165) | Living unbanked | Core demand — bank-free users | ✅ PR #173 · @Oluwasuyi-Timilehin |
 | V-13 | [#166](https://github.com/ericmt-98/micopay-protocol/issues/166) | Remittance sender | Cross-border demand (sender side) | ✅ PR #171 · @Jo-anny |
-| V-14 | [#167](https://github.com/ericmt-98/micopay-protocol/issues/167) | Stablecoin / digital peso mental model | Stellar stablecoin layer trust | 🆕 Open |
+| V-14 | [#167](https://github.com/ericmt-98/micopay-protocol/issues/167) | Stablecoin / digital peso mental model | Stellar stablecoin layer trust | ✅ PR #170 · @Max-Owolabi |
 | V-15 | [#168](https://github.com/ericmt-98/micopay-protocol/issues/168) | First-time trust threshold | PMF — first adoption barrier | 🆕 Open |
 
 ## After answers come in

--- a/docs/WAVE6_RESEARCH_ISSUES.md
+++ b/docs/WAVE6_RESEARCH_ISSUES.md
@@ -32,7 +32,7 @@
 |----|-------|-------|-------------------------|--------|
 | V-1 | [#131](https://github.com/ericmt-98/micopay-protocol/issues/131) | Cash-out context | User-side demand (digital → cash) | ✅ PR #155 · @larryjay007 |
 | V-2 | [#132](https://github.com/ericmt-98/micopay-protocol/issues/132) | Cash-in / deposit | Bidirectional demand (cash → digital) | ✅ PR #159 · @Truphile |
-| V-3 | [#133](https://github.com/ericmt-98/micopay-protocol/issues/133) | Liquidity provider | Supply side (who provides the cash) | 🔴 Open — no PR yet |
+| V-3 | [#133](https://github.com/ericmt-98/micopay-protocol/issues/133) | Liquidity provider | Supply side (who provides the cash) | ✅ PR #169 · @DevSolex |
 | V-4 | [#134](https://github.com/ericmt-98/micopay-protocol/issues/134) | Non-custodial onboarding | Stellar self-custody usable by normal users | ✅ PR #157 · @Shadow-MMN |
 | V-5 | [#135](https://github.com/ericmt-98/micopay-protocol/issues/135) | Trust in the flow | Trust / product-market fit | ✅ PR #158 · @Truphile |
 | V-6 | [#138](https://github.com/ericmt-98/micopay-protocol/issues/138) | Remittances cash-out | Cross-border remittance demand (receiver) | ✅ PR #146 · @KaruG1999 |
@@ -42,7 +42,7 @@
 | V-10 | [#142](https://github.com/ericmt-98/micopay-protocol/issues/142) | Repeat use & discovery | Retention / sustained usage | ✅ PR #143 · @attyolu |
 | V-11 | [#164](https://github.com/ericmt-98/micopay-protocol/issues/164) | Failed transaction / dispute | Trust recovery after failure | 🆕 Open |
 | V-12 | [#165](https://github.com/ericmt-98/micopay-protocol/issues/165) | Living unbanked | Core demand — bank-free users | 🆕 Open |
-| V-13 | [#166](https://github.com/ericmt-98/micopay-protocol/issues/166) | Remittance sender | Cross-border demand (sender side) | 🆕 Open |
+| V-13 | [#166](https://github.com/ericmt-98/micopay-protocol/issues/166) | Remittance sender | Cross-border demand (sender side) | ✅ PR #171 · @Jo-anny |
 | V-14 | [#167](https://github.com/ericmt-98/micopay-protocol/issues/167) | Stablecoin / digital peso mental model | Stellar stablecoin layer trust | 🆕 Open |
 | V-15 | [#168](https://github.com/ericmt-98/micopay-protocol/issues/168) | First-time trust threshold | PMF — first adoption barrier | 🆕 Open |
 

--- a/docs/WAVE6_RESEARCH_ISSUES.md
+++ b/docs/WAVE6_RESEARCH_ISSUES.md
@@ -28,18 +28,23 @@
 
 ## The 10 issues
 
-| ID | Issue | Topic | What it validates (SDF) |
-|----|-------|-------|-------------------------|
-| V-1 | [#131](https://github.com/ericmt-98/micopay-protocol/issues/131) | Cash-out context | User-side demand (digital → cash) |
-| V-2 | [#132](https://github.com/ericmt-98/micopay-protocol/issues/132) | Cash-in / deposit | Bidirectional demand (cash → digital) |
-| V-3 | [#133](https://github.com/ericmt-98/micopay-protocol/issues/133) | Liquidity provider | Supply side (who provides the cash) |
-| V-4 | [#134](https://github.com/ericmt-98/micopay-protocol/issues/134) | Non-custodial onboarding | Stellar self-custody usable by normal users |
-| V-5 | [#135](https://github.com/ericmt-98/micopay-protocol/issues/135) | Trust in the flow | Trust / product-market fit |
-| V-6 | [#138](https://github.com/ericmt-98/micopay-protocol/issues/138) | Remittances cash-out | Cross-border remittance demand |
-| V-7 | [#139](https://github.com/ericmt-98/micopay-protocol/issues/139) | Alternatives & switching | Differentiation vs current options |
-| V-8 | [#140](https://github.com/ericmt-98/micopay-protocol/issues/140) | Fair commission / fee | Unit economics (acceptable fee %) |
-| V-9 | [#141](https://github.com/ericmt-98/micopay-protocol/issues/141) | Safety meeting in person | De-risking P2P adoption |
-| V-10 | [#142](https://github.com/ericmt-98/micopay-protocol/issues/142) | Repeat use & discovery | Retention / sustained usage |
+| ID | Issue | Topic | What it validates (SDF) | Status |
+|----|-------|-------|-------------------------|--------|
+| V-1 | [#131](https://github.com/ericmt-98/micopay-protocol/issues/131) | Cash-out context | User-side demand (digital → cash) | ✅ PR #155 · @larryjay007 |
+| V-2 | [#132](https://github.com/ericmt-98/micopay-protocol/issues/132) | Cash-in / deposit | Bidirectional demand (cash → digital) | ✅ PR #159 · @Truphile |
+| V-3 | [#133](https://github.com/ericmt-98/micopay-protocol/issues/133) | Liquidity provider | Supply side (who provides the cash) | 🔴 Open — no PR yet |
+| V-4 | [#134](https://github.com/ericmt-98/micopay-protocol/issues/134) | Non-custodial onboarding | Stellar self-custody usable by normal users | ✅ PR #157 · @Shadow-MMN |
+| V-5 | [#135](https://github.com/ericmt-98/micopay-protocol/issues/135) | Trust in the flow | Trust / product-market fit | ✅ PR #158 · @Truphile |
+| V-6 | [#138](https://github.com/ericmt-98/micopay-protocol/issues/138) | Remittances cash-out | Cross-border remittance demand (receiver) | ✅ PR #146 · @KaruG1999 |
+| V-7 | [#139](https://github.com/ericmt-98/micopay-protocol/issues/139) | Alternatives & switching | Differentiation vs current options | ✅ PR #145 · @barnabasolutayo-lgtm |
+| V-8 | [#140](https://github.com/ericmt-98/micopay-protocol/issues/140) | Fair commission / fee | Unit economics (acceptable fee %) | ✅ PR #148 · @rosemary21 |
+| V-9 | [#141](https://github.com/ericmt-98/micopay-protocol/issues/141) | Safety meeting in person | De-risking P2P adoption | ✅ PR #147 · @deep-bhikadiya |
+| V-10 | [#142](https://github.com/ericmt-98/micopay-protocol/issues/142) | Repeat use & discovery | Retention / sustained usage | ✅ PR #143 · @attyolu |
+| V-11 | [#164](https://github.com/ericmt-98/micopay-protocol/issues/164) | Failed transaction / dispute | Trust recovery after failure | 🆕 Open |
+| V-12 | [#165](https://github.com/ericmt-98/micopay-protocol/issues/165) | Living unbanked | Core demand — bank-free users | 🆕 Open |
+| V-13 | [#166](https://github.com/ericmt-98/micopay-protocol/issues/166) | Remittance sender | Cross-border demand (sender side) | 🆕 Open |
+| V-14 | [#167](https://github.com/ericmt-98/micopay-protocol/issues/167) | Stablecoin / digital peso mental model | Stellar stablecoin layer trust | 🆕 Open |
+| V-15 | [#168](https://github.com/ericmt-98/micopay-protocol/issues/168) | First-time trust threshold | PMF — first adoption barrier | 🆕 Open |
 
 ## After answers come in
 


### PR DESCRIPTION
## Wave 6 — sync research validation into main

Brings the latest Drips research contributions and report corrections from `feat/wave6` into `main`.

### Validation data
- **V-11** (Failed transaction / dispute — @Chigybillionz, Nigeria) integrated into `VALIDATION_DRIPS.md` from #174.
- **V-14** PR link corrected #170 → #175 (@Max-Owolabi).
- All of V-1…V-14 now present; **V-15 is the sole remaining open research issue**.

### Report corrections (EN + ES)
- Status for closed-PR contributions (#159, #158, #171) corrected from "Merged" to "Integrated" (content landed via branch sync, PRs were closed not merged).
- Added V-11 row + detail entry; bumped N=16→17; regions Nigeria ×6.
- Fixed SDF coverage table (V-14 → Claim 4, V-11 → Claim 5).
- Resolved stale "open issues" line (only V-15 remains).

### APK audit (`AUDIT_APK_WAVE6.md`)
- §7 marked resolved: V-3 (#169), V-11 (#174), V-12 (#173), V-13 (#171), V-14 (#175).
- Research progress 9/15 → 14/15; V-15 is the sole open item.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
