### PR TITLE
fix(frontend): repair broken tsc build (duplicate identifier + null-safety)

### DIFF
--- a/micopay/frontend/src/App.tsx
+++ b/micopay/frontend/src/App.tsx
@@ -79,7 +79,6 @@ interface AppCtx {
   setReleaseTxHash: (h: string | null) => void;
   handleOfferSelected: (offerId: string) => Promise<boolean>;
   handleDepositOfferSelected: (offerId: string) => Promise<boolean>;
-  tradeError: MappedApiError | null;
   clearTradeError: () => void;
   retryTradeFlow: () => Promise<boolean>;
   handleAccountDeleted: () => void;

--- a/micopay/frontend/src/pages/QRReveal.tsx
+++ b/micopay/frontend/src/pages/QRReveal.tsx
@@ -64,13 +64,14 @@ const QRReveal = ({ activeTrade, sellerToken, buyerToken, amount, onBack, onChat
 
     const completePurchase = async () => {
         if (isConfirming || !secretLoaded || secretError) return;
+        if (!activeTrade || !buyerToken) return;
         setIsConfirming(true);
         setCompleteError(null);
         setTradeState('pending_cash');
         try {
             const result = await completeTrade(activeTrade.id, buyerToken);
             setTradeState('completed');
-            setTimeout(() => onSuccess(), 1500);
+            setTimeout(() => onSuccess(result.release_tx_hash), 1500);
         } catch (e) {
             setCompleteError(mapApiError(e));
             setTradeState('revealed');


### PR DESCRIPTION
## Fix the broken frontend `tsc` build

The frontend build was red on the branch (pre-existing breakage, surfaced by CI on #176 which was docs-only). This restores a green `tsc` + `vite build`.

### Root causes
- **`App.tsx`** — `tradeError` was declared twice in the `AppCtx` interface (a merge artifact from the error-states integration). `TS2300: Duplicate identifier 'tradeError'`.
- **`QRReveal.tsx`** — `completePurchase` called `completeTrade(activeTrade.id, buyerToken)` without null guards (`TS18047`, `TS2345`) and called `onSuccess()` with no argument despite its `(releaseTxHash: string)` signature (`TS2554`).

### Fix
- Removed the duplicate `tradeError` field.
- Added an `if (!activeTrade || !buyerToken) return;` guard and passed `result.release_tx_hash` into `onSuccess`.

### Verification
- `npx tsc --noEmit` → exit 0
- `npx vite build` → exit 0 (only the pre-existing chunk-size warning, tracked as P2-3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
