### PR TITLE
fix(frontend): label Blend DeFi result as simulated (P2-2)

### DIFF
--- a/micopay/frontend/src/pages/BlendScreen.tsx
+++ b/micopay/frontend/src/pages/BlendScreen.tsx
@@ -103,9 +103,14 @@ const BlendScreen = ({ onBack }: BlendScreenProps) => {
       <div className="flex items-center gap-2">
         <span className="material-symbols-outlined text-[#1D9E75] text-xl">check_circle</span>
         <p className="font-bold text-[#1D9E75]">
-          {result.simulated ? '¡Prueba exitosa!' : '¡Operación enviada!'}
+          {result.simulated ? '¡Prueba simulada!' : '¡Operación enviada!'}
         </p>
       </div>
+      {result.simulated && (
+        <p className="text-xs text-on-surface-variant">
+          Demostración — no se movieron fondos reales on-chain.
+        </p>
+      )}
       <p className="text-xs text-on-surface-variant font-mono">{shortHash(result.hash)}</p>
       <a
         href={result.explorerUrl}


### PR DESCRIPTION
## P2-2 — label Blend DeFi result as simulated

`BlendScreen` showed **"¡Prueba exitosa!"** when `result.simulated === true`, which reads like a real on-chain operation. `CETESScreen` already labeled this correctly as "¡Prueba simulada!".

### Fix
- Blend result card now shows **"¡Prueba simulada!"** in simulated mode (consistent with CETES).
- Added an explicit caption: *"Demostración — no se movieron fondos reales on-chain."*

Satisfies the P2-2 acceptance criterion (no simulated transaction presented as real without a visible label). DeFi remains simulated by decision D-3.

### Verification
- `npx tsc --noEmit` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
