### PR TITLE
fix(backend): harden DB fallback, demo seeding, health probe (B-3/B-4/B-7)

### DIFF
--- a/docs/AUDIT_APK_WAVE6.md
+++ b/docs/AUDIT_APK_WAVE6.md
@@ -38,7 +38,7 @@ es ahora deployable. Los P0 de frontend son el siguiente foco.
 | 🔴 P0 | 4 | Identidad doble, trade contra sí mismo, balance falso, fetch roto en APK |
 | 🟠 P1 | 4 | UI descarta datos reales (mapa, economía de oferta, nombres, tipo de cambio) |
 | 🟡 P2 | 1 | Config de release APK (P2-3) — DeFi simulado etiquetado ✅, CI ✅ |
-| ⚠️ B pendiente | 3 | B-3 (fallback in-memory), B-4 (seed en prod), B-7 (health real) — trabajo interno |
+| ~~⚠️ B pendiente~~ | ~~3~~ | ~~B-3, B-4, B-7~~ → ✅ **Resueltos 2026-06-28** (hardening backend interno) |
 
 ---
 
@@ -222,9 +222,9 @@ lo demás.
 | P1-3 | Nombre real del agente en recibo | `wave:frontend` | `wave:retail` | low | ✅ | 📎 **Plegado a #160** — `seller_username` ya se fetchea, falta cablear `agentName`; mismo `App.tsx` que P0-1/P0-2 |
 | ~~P1-4~~ | ~~Tipo de cambio XLM→MXN real~~ | — | — | — | — | ✅ **Resuelto** — PR #162 · @josealfredo79 · follow-up: P2-4 caché |
 | ~~P2-4~~ | ~~Caché en-memoria para `/rate/xlm-mxn`~~ | — | — | — | — | ✅ **Resuelto** — PR #172 · @josealfredo79 |
-| B-3 | Desactivar fallback in-memory en prod | `wave:backend` | `wave:trust` | medium | — | **Interno** — `initPg()` aún silencioso; no publicar como Drips |
-| B-4 | No sembrar datos demo en prod | `wave:backend` | `wave:trust` | low | — | **Interno** — `seedData()` sin flag; no publicar como Drips |
-| B-7 | Health/readiness real (DB + config) | `wave:backend` | `wave:trust` | medium | — | **Interno** — `/health` parcial; no publicar como Drips |
+| ~~B-3~~ | ~~Desactivar fallback in-memory en prod~~ | — | — | — | — | ✅ **Resuelto 2026-06-28** — `initPg()` hace `process.exit(1)` en prod si PG no conecta (salvo `ALLOW_IN_MEMORY_DB=true`) |
+| ~~B-4~~ | ~~No sembrar datos demo en prod~~ | — | — | — | — | ✅ **Resuelto 2026-06-28** — `seedData()` solo corre con `SEED_DEMO_DATA=true` |
+| ~~B-7~~ | ~~Health/readiness real (DB + config)~~ | — | — | — | — | ✅ **Resuelto 2026-06-28** — `/health` hace ping real `SELECT 1` (`pingDb()`); 503 en prod si DB caída |
 | ~~P2-2~~ | ~~Etiquetar DeFi como simulado~~ | — | — | — | — | ✅ **Resuelto** — etiquetado CETES + Blend (PR #178, D-3); issue #86 (wave anterior) |
 | ~~P2-3~~ | ~~Config de release APK~~ | — | — | — | — | Cerrado como issue #89 (wave anterior) |
 
@@ -267,8 +267,8 @@ lo demás.
 7. ~~**P1-2**~~ ✅ PR #156 · @Gozirimdev. **P1-1** (issue #151, abierto sin asignar).
 8. ~~**P1-4**~~ ✅ PR #162 · @josealfredo79. **P1-3** espera P0-2. ~~**P2-4**~~ ✅ PR #172 · @josealfredo79.
 
-**Etapa 3 — Backend hardening (interno):**
-9. **B-3, B-4, B-7** — trabajo interno pendiente. ~~B-2~~✅ ~~B-6~~✅
+**Etapa 3 — Backend hardening (interno):** ✅ COMPLETA
+9. ~~**B-3, B-4, B-7**~~ ✅ resueltos 2026-06-28. ~~B-2~~✅ ~~B-6~~✅
 
 **Etapa 4 — Decisiones de producto / release:**
 10. ~~**P2-2**~~ ✅ etiquetado simulado (PR #178). **P2-3** (config de release APK) sigue pendiente.
@@ -345,10 +345,11 @@ datos personales ni detalles que identifiquen a participantes.
 
 ## 8. Backend readiness para servidor
 
-> **Actualización 2026-06-25:** B-1 y P2-1 están resueltos (ver tabla abajo). B-5 se trata
-> internamente. B-3, B-4 y B-7 tienen trabajo pendiente puntual.
+> **Actualización 2026-06-28:** B-1, B-2, B-6 y P2-1 resueltos; **B-3, B-4 y B-7 también resueltos
+> (hardening backend interno)**. Solo queda B-5 (Dockerfile/guía de deploy), que se trata
+> internamente. El backend interno ya no tiene pendientes de readiness.
 
-### Estado de los issues internos (verificado 2026-06-25)
+### Estado de los issues internos (verificado 2026-06-28)
 
 | ID | Título | Estado | Evidencia |
 |----|--------|--------|-----------|
@@ -357,9 +358,9 @@ datos personales ni detalles que identifiquen a participantes.
 | **B-2** | Config prod fail-fast si faltan secretos | ✅ **Resuelto** | `validateConfig()` en `src/config.ts:92` lanza error y `start()` crashea via `process.exit(1)` si faltan `DATABASE_URL`, `SECRET_ENCRYPTION_KEY` o variables Stellar en modo real |
 | **B-6** | Migraciones / `init.sql` duplicado | ✅ **Resuelto** | `sql/init.sql` eliminado; schema vive en `src/db/schema.ts`; la tabla duplicada y el `audit_log` doble ya no existen |
 | **B-5** | Dockerfile / guía de deploy | — | Trabajo interno de maintainer; no se publica como issue Drips |
-| **B-3** | Desactivar fallback in-memory en prod | ⚠️ **Pendiente puntual** | `initPg()` corre a nivel de módulo y activa in-memory silenciosamente si Postgres falla. `validateConfig` solo verifica que `DATABASE_URL` no sea string vacío, no conectividad real. Criterio original: proceso falla si PG no conecta en producción |
-| **B-4** | No sembrar datos demo en producción | ⚠️ **Pendiente puntual** | `seedData()` en `src/index.ts:210` siembra sin flag explícito. Criterio original: seed solo corre con `SEED_DEMO_DATA=true` |
-| **B-7** | Health/readiness real | ⚠️ **Parcial** | `/health` expone `hasPlatformKey/hasDbUrl` (checks de string) y `eventListenerHealthy`, pero no verifica conectividad real al pool PG en cada request. Suficiente para demo; no suficiente como readiness probe de producción |
+| **B-3** | Desactivar fallback in-memory en prod | ✅ **Resuelto** | `initPg()` (`src/db/schema.ts`): si PG no conecta y `config.isProduction`, hace `console.error` + `process.exit(1)`; el fallback in-memory solo se permite con `ALLOW_IN_MEMORY_DB=true` (opt-in explícito, ya no silencioso). Verificado: `NODE_ENV=production` sin DB → exit 1 |
+| **B-4** | No sembrar datos demo en producción | ✅ **Resuelto** | `start()` (`src/index.ts`) solo llama `seedData()` si `config.seedDemoData` (`SEED_DEMO_DATA === 'true'`); si no, loguea que se omite. DB de producción nueva ya no se siembra |
+| **B-7** | Health/readiness real | ✅ **Resuelto** | nuevo `pingDb()` hace `SELECT 1` real contra el pool; `/health` lo expone como `dbConnected` y responde **503** en producción si la DB está caída (readiness probe real), además de los checks de config previos |
 
 ---
 

--- a/micopay/backend/src/config.ts
+++ b/micopay/backend/src/config.ts
@@ -56,8 +56,19 @@ export const config = {
   cetesIssuer: process.env.CETES_ISSUER || 'GCRYUGD5NVARGXT56XEZI5CIFCQETYHAPQQTHO2O3IQZTHDH4LATMYWC',
   blendPoolId: process.env.BLEND_POOL_ID || 'CB5UDFTJ6VFOK63ZHQASNODV4PP2HVGPYRF754LRGO7YRG5SFCAZWTDD',
 
+  // Environment
+  nodeEnv: process.env.NODE_ENV || 'development',
+  isProduction: process.env.NODE_ENV === 'production',
+
   // MVP flags
   mockStellar: process.env.MOCK_STELLAR === 'true',
+
+  // Demo data seeding (B-4): only seed when explicitly enabled
+  seedDemoData: process.env.SEED_DEMO_DATA === 'true',
+
+  // DB fallback (B-3): the ephemeral in-memory store is an explicit opt-in only;
+  // in production a missing PostgreSQL connection is fatal unless this is set.
+  allowInMemoryDb: process.env.ALLOW_IN_MEMORY_DB === 'true',
 
   // Soroban event listener (off by default; polling fallback covers the rest)
   eventListenerEnabled: process.env.EVENT_LISTENER_ENABLED === 'true',

--- a/micopay/backend/src/db/schema.ts
+++ b/micopay/backend/src/db/schema.ts
@@ -260,7 +260,18 @@ async function initPg() {
     pgPool = p;
     pgAvailable = true;
     console.log("✅ PostgreSQL connected");
-  } catch {
+  } catch (err) {
+    // B-3: never fall back to the ephemeral in-memory store in production
+    // unless explicitly opted in. A silent fallback would serve/lose real
+    // user data on a volatile store, so fail fast instead.
+    if (config.isProduction && !config.allowInMemoryDb) {
+      console.error(
+        "❌ PostgreSQL unavailable in production and ALLOW_IN_MEMORY_DB is not set — " +
+          "refusing to start on an ephemeral in-memory store. Exiting.",
+        err instanceof Error ? err.message : err,
+      );
+      process.exit(1);
+    }
     pgAvailable = false;
     console.warn(
       "⚠️  PostgreSQL unavailable — using in-memory store (data resets on restart)",
@@ -271,6 +282,21 @@ async function initPg() {
 await initPg();
 
 export const pool = pgPool;
+
+/**
+ * B-7: live readiness check. Returns true only when a real PostgreSQL
+ * round-trip (`SELECT 1`) succeeds. Returns false on the in-memory fallback
+ * or when the pool has gone away — so it can back a real readiness probe.
+ */
+export async function pingDb(): Promise<boolean> {
+  if (!pgAvailable || !pgPool) return false;
+  try {
+    await pgPool.query("SELECT 1");
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export async function query(text: string, params?: any[]) {
   if (pgAvailable && pgPool) return pgPool.query(text, params);
@@ -358,4 +384,4 @@ export async function insertUnique<T = any>(
   return (rows[0] as T) ?? null;
 }
 
-export default { pool, query, getOne, getMany, execute, insertUnique };
+export default { pool, query, getOne, getMany, execute, insertUnique, pingDb };

--- a/micopay/backend/src/index.ts
+++ b/micopay/backend/src/index.ts
@@ -2,6 +2,7 @@ import Fastify from 'fastify';
 import fastifyJwt from '@fastify/jwt';
 import fastifyCors from '@fastify/cors';
 import { config, validateConfig } from './config.js';
+import { pingDb } from './db/schema.js';
 import { authRoutes } from './routes/auth.js';
 import { userRoutes } from './routes/users.js';
 import { tradeRoutes } from './routes/trades.js';
@@ -164,19 +165,29 @@ app.setErrorHandler((error, request, reply) => {
 // Holds the singleton event listener (null when disabled or mock mode).
 let eventListener: EscrowEventListener | null = null;
 
-app.get('/health', async () => ({
-  status: 'ok',
-  timestamp: new Date().toISOString(),
-  mockStellar: config.mockStellar,
-  eventListenerHealthy: eventListener?.isHealthy() ?? false,
-  eventListenerState: eventListener?.currentState() ?? 'disabled',
-  configCheck: {
-    hasPlatformKey: !!config.platformSecretKey,
-    hasContractId: !!config.escrowContractId,
-    hasDbUrl: !!config.databaseUrl,
-    hasSecretKey: !!config.secretEncryptionKey,
-  }
-}));
+app.get('/health', async (_request, reply) => {
+  // B-7: real readiness — actually round-trip to PostgreSQL, don't just
+  // check that a connection string is present.
+  const dbConnected = await pingDb();
+  // In production a live DB is required to be "ready"; outside production the
+  // in-memory fallback is acceptable for demos/tests.
+  const ready = dbConnected || !config.isProduction;
+  if (!ready) reply.code(503);
+  return {
+    status: ready ? 'ok' : 'unavailable',
+    timestamp: new Date().toISOString(),
+    mockStellar: config.mockStellar,
+    dbConnected,
+    eventListenerHealthy: eventListener?.isHealthy() ?? false,
+    eventListenerState: eventListener?.currentState() ?? 'disabled',
+    configCheck: {
+      hasPlatformKey: !!config.platformSecretKey,
+      hasContractId: !!config.escrowContractId,
+      hasDbUrl: !!config.databaseUrl,
+      hasSecretKey: !!config.secretEncryptionKey,
+    }
+  };
+});
 
 // Platform account balance from Horizon (public, no auth needed)
 app.get('/account/balance', async (request) => {
@@ -287,8 +298,16 @@ async function start() {
   try {
     // Validate config at startup. Will throw and crash if critical config is missing.
     validateConfig();
-    
-    await seedData();
+
+    // B-4: only seed demo data when explicitly enabled — never in a fresh prod DB.
+    if (config.seedDemoData) {
+      await seedData();
+    } else {
+      app.log.info(
+        { category: 'seed' },
+        'Skipping demo seed (set SEED_DEMO_DATA=true to enable)',
+      );
+    }
     await app.listen({ port: config.port, host: '0.0.0.0' });
     app.log.info({ category: 'http', port: config.port }, '🍄 Micopay MVP Backend running');
     app.log.info({ category: 'http', mockStellar: config.mockStellar }, `Mock Stellar: ${config.mockStellar ? 'ON (no on-chain verification)' : 'OFF (real Soroban RPC)'}`);


### PR DESCRIPTION
## Backend hardening — B-3 / B-4 / B-7 (internal readiness)

Closes the three remaining internal backend items from the Wave 6 audit (§8). Internal hardening, not Drips-facing.

### B-3 — no silent in-memory fallback in production
`initPg()` silently fell back to the ephemeral in-memory store when PostgreSQL was unreachable — in production that would serve/lose real user data on a volatile store. Now: in production it `console.error` + `process.exit(1)`, unless `ALLOW_IN_MEMORY_DB=true` is set as an explicit opt-in. Dev/tests keep the fallback.

### B-4 — never seed demo data in a fresh prod DB
`seedData()` ran unconditionally (only checking whether trades already existed). Now `start()` only seeds when `SEED_DEMO_DATA=true`, and logs that it was skipped otherwise.

### B-7 — real readiness probe
`/health` only did string checks (`!!config.databaseUrl`). Added `pingDb()` which runs a real `SELECT 1`; `/health` now reports `dbConnected` and returns **503** in production when the DB is down.

`config.ts`: added `nodeEnv`/`isProduction`, `seedDemoData`, `allowInMemoryDb`.

### Verification
- `npm run build` (backend tsc) → exit 0
- All backend tests pass (abuse, rate-limit, event-listener, accountDeletion, rateCache, requestId)
- Smoke test: `NODE_ENV=production` + unreachable DB → **exit 1**; with `ALLOW_IN_MEMORY_DB=true` → continues on in-memory
- Audit `AUDIT_APK_WAVE6.md` updated (§0, §6.2, §6.3, §8) marking B-3/B-4/B-7 resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
