### PR TITLE
docs(wave6): fix leftover V-14 link + N count in contributor reports

### DIFF
--- a/docs/WAVE6_CONTRIBUTORS_REPORT.md
+++ b/docs/WAVE6_CONTRIBUTORS_REPORT.md
@@ -74,7 +74,7 @@ Each contribution advances one or more of the five claims in our funding narrati
 ---
 
 ### V-2 · Cash-in / deposit context
-**Contributor:** [@Truphile](https://github.com/Truphile) · **PR:** [#159](https://github.com/ericmt-98/micopay-protocol/pull/159) · **Merged:** 2026-06-25
+**Contributor:** [@Truphile](https://github.com/Truphile) · **PR:** [#159](https://github.com/ericmt-98/micopay-protocol/pull/159) · **Integrated:** 2026-06-25
 
 **Format:** First-person, single respondent.
 
@@ -110,7 +110,7 @@ Each contribution advances one or more of the five claims in our funding narrati
 ---
 
 ### V-5 · Trust in the cash-in/cash-out flow
-**Contributor:** [@Truphile](https://github.com/Truphile) · **PR:** [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) · **Merged:** 2026-06-25
+**Contributor:** [@Truphile](https://github.com/Truphile) · **PR:** [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) · **Integrated:** 2026-06-25
 
 **Format:** First-person, single respondent.
 
@@ -230,7 +230,7 @@ Each contribution advances one or more of the five claims in our funding narrati
 ---
 
 ### V-14 · Stablecoin / digital peso mental model
-**Contributor:** [@Max-Owolabi](https://github.com/Max-Owolabi) · **PR:** [#170](https://github.com/ericmt-98/micopay-protocol/pull/170) · **Merged:** 2026-06-26
+**Contributor:** [@Max-Owolabi](https://github.com/Max-Owolabi) · **PR:** [#175](https://github.com/ericmt-98/micopay-protocol/pull/175) · **Integrated:** 2026-06-27
 
 **Format:** First-person, single respondent.
 
@@ -288,7 +288,7 @@ Each contribution advances one or more of the five claims in our funding narrati
 ---
 
 ### V-13 · Remittance sender context — sending money abroad
-**Contributor:** [@Jo-anny](https://github.com/Jo-anny) · **PR:** [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) · **Merged:** 2026-06-26
+**Contributor:** [@Jo-anny](https://github.com/Jo-anny) · **PR:** [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) · **Integrated:** 2026-06-26
 
 **Format:** First-person, single respondent.
 
@@ -374,9 +374,9 @@ Responses now span 6+ countries across 3 continents (LATAM, South Asia, Africa).
 - **First-person** entries reflect each contributor's own lived experience — not a survey of others.
 - **Convenience sample**, self-selected via Stellar Drips Wave 6. Directional and qualitative, not statistically representative.
 - **Privacy-first:** no names, no contact information, no transaction amounts, no wallet addresses.
-- Current sample size: **N=16 individual perspectives** across **7+ countries / 3 regions**.
+- Current sample size: **N=17 individual perspectives** across **7+ countries / 3 regions**.
 - Report `N` plainly. Let the cross-regional consistency of the patterns speak for itself.
 
 ---
 
-*Last updated: 2026-06-26 · Maintainer: [@ericmt-98](https://github.com/ericmt-98)*
+*Last updated: 2026-06-27 · Maintainer: [@ericmt-98](https://github.com/ericmt-98)*

--- a/docs/WAVE6_CONTRIBUTORS_REPORT_ES.md
+++ b/docs/WAVE6_CONTRIBUTORS_REPORT_ES.md
@@ -74,7 +74,7 @@ Cada contribución avanza uno o más de los cinco argumentos de nuestra narrativ
 ---
 
 ### V-2 · Contexto de cash-in / depósito
-**Contribuidor:** [@Truphile](https://github.com/Truphile) · **PR:** [#159](https://github.com/ericmt-98/micopay-protocol/pull/159) · **Mergeado:** 2026-06-25
+**Contribuidor:** [@Truphile](https://github.com/Truphile) · **PR:** [#159](https://github.com/ericmt-98/micopay-protocol/pull/159) · **Integrado:** 2026-06-25
 
 **Formato:** Primera persona, respondente único.
 
@@ -110,7 +110,7 @@ Cada contribución avanza uno o más de los cinco argumentos de nuestra narrativ
 ---
 
 ### V-5 · Confianza en el flujo de cash-in/cash-out
-**Contribuidor:** [@Truphile](https://github.com/Truphile) · **PR:** [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) · **Mergeado:** 2026-06-25
+**Contribuidor:** [@Truphile](https://github.com/Truphile) · **PR:** [#158](https://github.com/ericmt-98/micopay-protocol/pull/158) · **Integrado:** 2026-06-25
 
 **Formato:** Primera persona, respondente único.
 
@@ -249,7 +249,7 @@ Cada contribución avanza uno o más de los cinco argumentos de nuestra narrativ
 ---
 
 ### V-14 · Modelo mental de stablecoin y peso digital
-**Contribuidor:** [@Max-Owolabi](https://github.com/Max-Owolabi) · **PR:** [#170](https://github.com/ericmt-98/micopay-protocol/pull/170) · **Mergeado:** 2026-06-26
+**Contribuidor:** [@Max-Owolabi](https://github.com/Max-Owolabi) · **PR:** [#175](https://github.com/ericmt-98/micopay-protocol/pull/175) · **Integrado:** 2026-06-27
 
 **Formato:** Primera persona, respondente único.
 
@@ -288,7 +288,7 @@ Cada contribución avanza uno o más de los cinco argumentos de nuestra narrativ
 ---
 
 ### V-13 · Contexto del remitente — envío de dinero al exterior
-**Contribuidor:** [@Jo-anny](https://github.com/Jo-anny) · **PR:** [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) · **Mergeado:** 2026-06-26
+**Contribuidor:** [@Jo-anny](https://github.com/Jo-anny) · **PR:** [#171](https://github.com/ericmt-98/micopay-protocol/pull/171) · **Integrado:** 2026-06-26
 
 **Formato:** Primera persona, respondente único.
 
@@ -374,9 +374,9 @@ Las respuestas ya abarcan 6+ países en 3 continentes (LATAM, Sur de Asia, Áfri
 - **Primera persona:** cada entrada refleja la experiencia propia del contribuidor — no una encuesta a terceros.
 - **Muestra por conveniencia**, auto-seleccionada a través del programa Stellar Drips Wave 6. Señal direccional y cualitativa, no representativa estadísticamente.
 - **Privacy-first:** sin nombres, sin datos de contacto, sin montos de dinero, sin direcciones de wallet.
-- Tamaño actual de la muestra: **N=16 perspectivas individuales** en **7+ países / 3 regiones**.
+- Tamaño actual de la muestra: **N=17 perspectivas individuales** en **7+ países / 3 regiones**.
 - Reportar `N` con claridad. Dejar que la consistencia de los patrones entre regiones hable por sí sola.
 
 ---
 
-*Última actualización: 2026-06-26 · Maintainer: [@ericmt-98](https://github.com/ericmt-98)*
+*Última actualización: 2026-06-27 · Maintainer: [@ericmt-98](https://github.com/ericmt-98)*


### PR DESCRIPTION
Consistency cleanup in both contributor reports (EN + ES), finishing the V-11/V-14 sync:

- V-14 detail entry: PR #170 → #175, "Merged" → "Integrated"
- V-2 / V-5 / V-13 detail headers: "Merged" → "Integrated" (PRs closed, content integrated via branch)
- Methodology note: N=16 → N=17
- Last-updated date refreshed

Detail entries, overview table, coverage table and footer now all agree. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)