### PR TITLE
fix(frontend): use real merchant API data in ExploreMap offer cards (#151)

### DIFF
--- a/micopay/frontend/src/pages/ExploreMap.tsx
+++ b/micopay/frontend/src/pages/ExploreMap.tsx
@@ -35,11 +35,10 @@ function merchantToOffer(m: AvailableMerchant, index: number): Offer {
     id: m.seller_id,
     name: m.username,
     icon: 'storefront',
-    distance: '180 m',
-    walkMinutes: 3,
-    receiveMxn: 495,
-    commissionPct: 1,
-    badge: 'Negocio verificado',
+    distance: formatDistance(m.distance_km),
+    walkMinutes: walkMinutes(m.distance_km),
+    receiveMxn: m.payout_mxn,
+    commissionPct: m.rate_percent,
     isPrimary: index === 0,
   };
 }


### PR DESCRIPTION
## Summary

Fixes #151 — `ExploreMap` was showing identical placeholder economics on every merchant card because `merchantToOffer` ignored the fields returned by `GET /merchants/available`.

This PR wires `merchantToOffer` to the existing `AvailableMerchant` response so each card reflects that merchant's real distance, payout, and commission.

## What changed

**File:** `micopay/frontend/src/pages/ExploreMap.tsx`

`merchantToOffer` now maps API fields instead of hardcoded constants:

| API field (`AvailableMerchant`) | UI field (`Offer`) | Helper used |
|---|---|---|
| `distance_km` | `distance` | `formatDistance()` |
| `distance_km` | `walkMinutes` | `walkMinutes()` |
| `payout_mxn` | `receiveMxn` | — |
| `rate_percent` | `commissionPct` | — |
| `username` | `name` | *(already wired)* |

**Before:** every card showed `180 m`, `3 min`, `$495.00 MXN`, and `1%` commission.

**After:** each card shows values computed from that merchant's API response.

Also removed the hardcoded `badge: 'Negocio verificado'` since `AvailableMerchant` has no badge field — the badge UI remains optional and simply won't render when absent.

## Acceptance criteria

- [x] `merchantToOffer` maps `m.distance_km` → `formatDistance` / `walkMinutes`
- [x] `merchantToOffer` maps `m.payout_mxn` → `receiveMxn` and `m.rate_percent` → `commissionPct`
- [x] Each merchant card displays that merchant's real distance, payout, and commission
- [x] Empty merchant list handled gracefully via existing `EmptyState` (no crash)

## Scope

Frontend only — single-file change in `ExploreMap.tsx`. No backend or hook changes required; `useMerchantsAvailable` already returns the correct data.

## Test plan

- [ ] Open **Convertir a efectivo** with location permission granted
- [ ] Confirm multiple merchant cards show **different** distances, walk times, payouts, and commission percentages
- [ ] Confirm the primary ("Mejor oferta") card uses real values from the first merchant in the API response
- [ ] Confirm commission display (`$X.XX (Y%)`) matches `amount - payout_mxn` and `rate_percent`
- [ ] Test with no nearby merchants → empty state renders without errors
- [ ] Test location denied / fetch error paths still work (unchanged)