### PR TITLE
test(sec-10): add role-based authorization regression tests for trade…

### DIFF
--- a/docs/security-reports/SEC-10-state-machine-regresion.md
+++ b/docs/security-reports/SEC-10-state-machine-regresion.md
@@ -1,0 +1,85 @@
+# SEC-10 — Reporte de Regresión: Autorización por Rol en Trade State Machine
+
+**Fecha:** 2026-06-29  
+**Severidad:** ⚪ Informativa (los guards se mantienen en todos los casos)  
+**Issue:** [#217](https://github.com/ericmt-98/micopay-protocol/issues/217)
+
+---
+
+## Resumen
+
+Se realizaron pruebas de regresión sobre los guards de rol en `micopay/backend/src/services/trade.service.ts`. El objetivo era confirmar que ninguna transición de estado puede ser ejecutada por un actor no autorizado, y que no existen rutas alternativas (endpoints de demo, seed, admin) que salten estos guards.
+
+**Resultado: todos los guards se mantienen.** No se encontró ningún bypass.
+
+---
+
+## Guards verificados
+
+| Función | Línea aprox. | Rol permitido | Método de verificación |
+|---|---|---|---|
+| `lockTrade` | ~117 | Solo seller | Test: buyer y tercero reciben 403 |
+| `revealTrade` | ~165 | Solo seller | Test: buyer y tercero reciben 403 |
+| `getTradeSecret` | ~183 | Solo seller | Test: buyer y tercero reciben 403 |
+| `completeTrade` | ~215 | Solo buyer | Test: seller y tercero reciben 403 |
+| `getTradeById` | ~239 | Seller o buyer | Test: tercero recibe 403 |
+
+---
+
+## Casos de prueba ejecutados
+
+Todos los tests están en `micopay/backend/src/tests/tradeAuth.test.ts` y se ejecutan con:
+
+```bash
+npm run test:trade-auth
+# Equivalente a: node --import tsx src/tests/tradeAuth.test.ts
+```
+
+### Resultados
+
+```
+SEC-10 — Role-based authorization regression tests
+
+  ✓ lockTrade: buyer cannot lock (403 ForbiddenError)
+  ✓ lockTrade: third party cannot lock (403 ForbiddenError)
+  ✓ revealTrade: buyer cannot reveal (403 ForbiddenError)
+  ✓ revealTrade: third party cannot reveal (403 ForbiddenError)
+  ✓ getTradeSecret: buyer cannot read secret (403 AuthError)
+  ✓ getTradeSecret: third party cannot read secret (403 AuthError)
+  ✓ completeTrade: seller cannot complete (403 ForbiddenError)
+  ✓ completeTrade: third party cannot complete (403 ForbiddenError)
+  ✓ getTradeById: third party cannot view trade details (403 AuthError)
+
+All SEC-10 role-authorization tests passed.
+```
+
+---
+
+## Análisis de rutas alternativas
+
+Se revisaron todos los endpoints registrados en el backend para identificar rutas que puedan modificar el estado de un trade sin pasar por los guards del servicio:
+
+| Archivo de rutas | Evaluación |
+|---|---|
+| `src/routes/trades.ts` | Todas las rutas usan `authMiddleware` y delegan a `trade.service.ts` — guards aplicados |
+| `src/routes/admin.ts` | No expone operaciones de estado de trade |
+| `src/routes/trade-safety.ts` | Solo lectura / métricas — no modifica estado |
+| `src/routes/auth.ts` | Solo autenticación |
+| `src/seed.ts` | Solo se ejecuta cuando `SEED_DEMO_DATA=true` en desarrollo; no expuesto como endpoint HTTP |
+
+**Conclusión:** No se encontró ninguna ruta alternativa que permita saltar los guards de rol.
+
+---
+
+## Vectores evaluados según el issue
+
+1. **Buyer intenta `POST /trades/{id}/reveal`** → `ForbiddenError` (403) ✅
+2. **Seller intenta `POST /trades/{id}/complete`** → `ForbiddenError` (403) ✅
+3. **Tercero intenta `GET /trades/{id}/secret`** → `AuthError` (403) ✅
+4. **Rutas de demo/seed sin guards** → No existen endpoints HTTP de seed; el archivo `seed.ts` solo se ejecuta via flag de configuración ✅
+
+---
+
+## Severidad final
+
+⚪ **Informativa** — los guards se mantienen correctamente en todos los casos de prueba. No se requiere acción correctiva.

--- a/micopay/backend/package.json
+++ b/micopay/backend/package.json
@@ -10,7 +10,8 @@
     "migrate": "tsx src/db/migrate.ts",
     "e2e": "node --import tsx ../scripts/e2e-test.ts",
     "test:rate-limit": "node --import tsx src/tests/rateLimit.test.ts",
-    "test:abuse": "node --import tsx src/tests/abuse.service.test.ts"
+    "test:abuse": "node --import tsx src/tests/abuse.service.test.ts",
+    "test:trade-auth": "ALLOW_IN_MEMORY_DB=true MOCK_STELLAR=true SECRET_ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000 node --import tsx src/tests/tradeAuth.test.ts"
   },
   "dependencies": {
     "@fastify/cors": "^8.5.0",

--- a/micopay/backend/src/tests/tradeAuth.test.ts
+++ b/micopay/backend/src/tests/tradeAuth.test.ts
@@ -1,0 +1,258 @@
+/**
+ * SEC-10 — Regression tests: Role-based authorization in the trade state machine.
+ *
+ * Verifies that the role guards in trade.service.ts are upheld:
+ *   - lockTrade:      only the seller may lock         (ForbiddenError)
+ *   - revealTrade:    only the seller may reveal       (ForbiddenError)
+ *   - getTradeSecret: only the seller may read secret  (AuthError / httpStatus 403)
+ *   - completeTrade:  only the buyer may complete      (ForbiddenError)
+ *
+ * Also confirms that a third party (neither buyer nor seller) is rejected by
+ * getTradeById (403) and therefore cannot reach any of those guarded paths.
+ *
+ * Runs against the in-memory DB (ALLOW_IN_MEMORY_DB=true, no PostgreSQL needed).
+ */
+
+import { strictEqual, ok } from "assert";
+import db from "../db/schema.js";
+import {
+  lockTrade,
+  revealTrade,
+  getTradeSecret,
+  completeTrade,
+  getTradeById,
+} from "../services/trade.service.js";
+import {
+  ForbiddenError,
+  AuthError,
+  AppError,
+} from "../utils/errors.js";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/** Minimal Fastify-request stub used by service functions. */
+const fakeRequest = {
+  ip: "127.0.0.1",
+  headers: {},
+  log: {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  },
+} as any;
+
+async function createUser(suffix: string): Promise<string> {
+  const row = await db.getOne<{ id: string }>(
+    `INSERT INTO users (stellar_address, username, phone_hash, merchant_available, availability, is_suspended)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING id`,
+    [
+      `G${"A".repeat(54)}${suffix.padStart(1, "0")}`,
+      `user_sec10_${suffix}`,
+      `hash_sec10_${suffix}`,
+      true,
+      "online",
+      false,
+    ],
+  );
+  if (!row?.id) throw new Error(`Failed to seed user ${suffix}`);
+  return row.id;
+}
+
+/**
+ * Insert a trade row directly into the in-memory store at a specific status.
+ * Returns the trade id.
+ */
+async function insertTrade(
+  sellerId: string,
+  buyerId: string,
+  status: string,
+): Promise<string> {
+  const { encryptSecret, generateTradeSecret } = await import(
+    "../services/secret.service.js"
+  );
+  const { secret, secretHash } = generateTradeSecret();
+  const { encrypted, nonce } = encryptSecret(secret);
+  const expiresAt = new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString();
+
+  const row = await db.getOne<{ id: string }>(
+    `INSERT INTO trades
+       (seller_id, buyer_id, amount_mxn, amount_stroops, platform_fee_mxn,
+        secret_hash, secret_enc, secret_nonce, status, expires_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+     RETURNING id`,
+    [
+      sellerId,
+      buyerId,
+      500,
+      "5000000000",
+      4,
+      secretHash,
+      encrypted,
+      nonce,
+      status,
+      expiresAt,
+    ],
+  );
+  if (!row?.id) throw new Error("Failed to insert trade");
+  return row.id;
+}
+
+/** Assert that calling `fn()` throws an AppError with httpStatus 403. */
+async function assert403(fn: () => Promise<unknown>, label: string) {
+  let threw = false;
+  try {
+    await fn();
+  } catch (err) {
+    threw = true;
+    ok(
+      err instanceof AppError && err.httpStatus === 403,
+      `${label}: expected AppError(403) but got ${(err as Error)?.constructor?.name} ${(err as any)?.httpStatus}`,
+    );
+  }
+  ok(threw, `${label}: expected an error to be thrown but none was`);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+async function testLockTradeByBuyerIsRejected() {
+  const sellerId = await createUser("s1");
+  const buyerId = await createUser("b1");
+  const tradeId = await insertTrade(sellerId, buyerId, "pending");
+
+  await assert403(
+    () => lockTrade(fakeRequest, tradeId, buyerId),
+    "lockTrade called by buyer",
+  );
+  console.log("  ✓ lockTrade: buyer cannot lock (403 ForbiddenError)");
+}
+
+async function testLockTradeByThirdPartyIsRejected() {
+  const sellerId = await createUser("s2");
+  const buyerId = await createUser("b2");
+  const thirdId = await createUser("t2");
+  const tradeId = await insertTrade(sellerId, buyerId, "pending");
+
+  await assert403(
+    () => lockTrade(fakeRequest, tradeId, thirdId),
+    "lockTrade called by third party",
+  );
+  console.log("  ✓ lockTrade: third party cannot lock (403 ForbiddenError)");
+}
+
+async function testRevealTradeByBuyerIsRejected() {
+  const sellerId = await createUser("s3");
+  const buyerId = await createUser("b3");
+  const tradeId = await insertTrade(sellerId, buyerId, "locked");
+
+  await assert403(
+    () => revealTrade(fakeRequest, tradeId, buyerId),
+    "revealTrade called by buyer",
+  );
+  console.log("  ✓ revealTrade: buyer cannot reveal (403 ForbiddenError)");
+}
+
+async function testRevealTradeByThirdPartyIsRejected() {
+  const sellerId = await createUser("s4");
+  const buyerId = await createUser("b4");
+  const thirdId = await createUser("t4");
+  const tradeId = await insertTrade(sellerId, buyerId, "locked");
+
+  await assert403(
+    () => revealTrade(fakeRequest, tradeId, thirdId),
+    "revealTrade called by third party",
+  );
+  console.log("  ✓ revealTrade: third party cannot reveal (403 ForbiddenError)");
+}
+
+async function testGetTradeSecretByBuyerIsRejected() {
+  const sellerId = await createUser("s5");
+  const buyerId = await createUser("b5");
+  const tradeId = await insertTrade(sellerId, buyerId, "revealing");
+
+  await assert403(
+    () => getTradeSecret(fakeRequest, tradeId, buyerId, "127.0.0.1", "test"),
+    "getTradeSecret called by buyer",
+  );
+  console.log("  ✓ getTradeSecret: buyer cannot read secret (403 AuthError)");
+}
+
+async function testGetTradeSecretByThirdPartyIsRejected() {
+  const sellerId = await createUser("s6");
+  const buyerId = await createUser("b6");
+  const thirdId = await createUser("t6");
+  const tradeId = await insertTrade(sellerId, buyerId, "revealing");
+
+  await assert403(
+    () => getTradeSecret(fakeRequest, tradeId, thirdId, "127.0.0.1", "test"),
+    "getTradeSecret called by third party",
+  );
+  console.log(
+    "  ✓ getTradeSecret: third party cannot read secret (403 AuthError)",
+  );
+}
+
+async function testCompleteTradeBySellerIsRejected() {
+  const sellerId = await createUser("s7");
+  const buyerId = await createUser("b7");
+  const tradeId = await insertTrade(sellerId, buyerId, "revealing");
+
+  await assert403(
+    () => completeTrade(fakeRequest, tradeId, sellerId),
+    "completeTrade called by seller",
+  );
+  console.log("  ✓ completeTrade: seller cannot complete (403 ForbiddenError)");
+}
+
+async function testCompleteTradeByThirdPartyIsRejected() {
+  const sellerId = await createUser("s8");
+  const buyerId = await createUser("b8");
+  const thirdId = await createUser("t8");
+  const tradeId = await insertTrade(sellerId, buyerId, "revealing");
+
+  await assert403(
+    () => completeTrade(fakeRequest, tradeId, thirdId),
+    "completeTrade called by third party",
+  );
+  console.log(
+    "  ✓ completeTrade: third party cannot complete (403 ForbiddenError)",
+  );
+}
+
+async function testGetTradeByIdThirdPartyIsRejected() {
+  const sellerId = await createUser("s9");
+  const buyerId = await createUser("b9");
+  const thirdId = await createUser("t9");
+  const tradeId = await insertTrade(sellerId, buyerId, "pending");
+
+  await assert403(
+    () => getTradeById(tradeId, thirdId),
+    "getTradeById called by third party",
+  );
+  console.log(
+    "  ✓ getTradeById: third party cannot view trade details (403 AuthError)",
+  );
+}
+
+// ── Runner ─────────────────────────────────────────────────────────────────
+
+async function run() {
+  console.log("\nSEC-10 — Role-based authorization regression tests\n");
+
+  await testLockTradeByBuyerIsRejected();
+  await testLockTradeByThirdPartyIsRejected();
+  await testRevealTradeByBuyerIsRejected();
+  await testRevealTradeByThirdPartyIsRejected();
+  await testGetTradeSecretByBuyerIsRejected();
+  await testGetTradeSecretByThirdPartyIsRejected();
+  await testCompleteTradeBySellerIsRejected();
+  await testCompleteTradeByThirdPartyIsRejected();
+  await testGetTradeByIdThirdPartyIsRejected();
+
+  console.log("\nAll SEC-10 role-authorization tests passed.\n");
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
… state machine

- Add micopay/backend/src/tests/tradeAuth.test.ts with 9 regression tests covering lockTrade (seller-only), revealTrade (seller-only), getTradeSecret (seller-only), completeTrade (buyer-only), and getTradeById (participants-only) guards
- Add test:trade-auth npm script to micopay/backend/package.json
- Add docs/security-reports/SEC-10-state-machine-regresion.md report

All 9 tests pass. tsc build is clean.
Closes #217