### PR TITLE
feat(frontend): mostrar costo total efectivo y guardrail >5% en ofertas

### DIFF
--- a/micopay/frontend/src/pages/DepositMap.tsx
+++ b/micopay/frontend/src/pages/DepositMap.tsx
@@ -1,6 +1,11 @@
 import MapSim from '../components/MapSim';
 import { useMerchantsAvailable } from '../hooks/useMerchantsAvailable';
-import type { AvailableMerchant } from '../services/api';
+import {
+  effectiveFeePercent,
+  MAX_EFFECTIVE_FEE_PERCENT,
+  type AvailableMerchant,
+} from '../services/api';
+import { PLATFORM_FEE_PERCENT } from '../constants/trade';
 import ErrorBanner from '../components/ErrorBanner';
 import type { ApiErrorAction } from '../utils/apiError';
 
@@ -22,6 +27,49 @@ interface DepositMapProps {
   creationErrorAction?: ApiErrorAction;
   onDismissCreationError?: () => void;
   onRetryCreationError?: () => void;
+  /** Effective-fee threshold (%) above which a warning is shown. Defaults to the shared guardrail. */
+  maxEffectiveFeePercent?: number;
+}
+
+// ─── Effective cost (provider + platform) + over-threshold warning ────────────
+
+function EffectiveFeeNote({
+  commissionPct,
+  platformFeePct,
+  maxPct,
+}: {
+  commissionPct: number;
+  platformFeePct: number;
+  maxPct: number;
+}) {
+  const totalPct = effectiveFeePercent(commissionPct, platformFeePct);
+  const exceeds = totalPct > maxPct;
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2 border-t border-outline-variant/10 pt-3">
+        <span className="text-xs text-on-surface-variant font-label uppercase">
+          Costo total efectivo
+        </span>
+        <span className={`text-sm font-bold tabular-nums ${exceeds ? 'text-error' : 'text-on-surface'}`}>
+          {totalPct.toFixed(1)}%
+        </span>
+      </div>
+      <p className="text-[11px] text-on-surface-variant">
+        Plataforma {platformFeePct}% + proveedor {commissionPct}%
+      </p>
+      {exceeds && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-lg border border-error/30 bg-error/5 px-3 py-2"
+        >
+          <span className="material-symbols-outlined text-error text-base leading-none">warning</span>
+          <p className="text-[12px] font-medium text-error leading-snug">
+            El costo total supera el {maxPct}%. Compara con otra oferta antes de continuar.
+          </p>
+        </div>
+      )}
+    </div>
+  );
 }
 
 // ─── Loading skeleton ─────────────────────────────────────────────────────────
@@ -179,11 +227,20 @@ interface MerchantCardProps {
   loading: boolean;
   isBest: boolean;
   onSelectOffer: (id: string) => void;
+  maxEffectiveFeePercent: number;
 }
 
-function MerchantOfferCard({ merchant, amount, loading, isBest, onSelectOffer }: MerchantCardProps) {
+function MerchantOfferCard({
+  merchant,
+  amount,
+  loading,
+  isBest,
+  onSelectOffer,
+  maxEffectiveFeePercent,
+}: MerchantCardProps) {
   const commissionMxn = (amount - merchant.payout_mxn).toFixed(2);
   const distanceLabel = formatDistance(merchant.distance_km);
+  const platformFeePct = merchant.platform_fee_pct ?? PLATFORM_FEE_PERCENT;
 
   if (isBest) {
     return (
@@ -243,6 +300,12 @@ function MerchantOfferCard({ merchant, amount, loading, isBest, onSelectOffer }:
             </div>
           </div>
 
+          <EffectiveFeeNote
+            commissionPct={merchant.rate_percent}
+            platformFeePct={platformFeePct}
+            maxPct={maxEffectiveFeePercent}
+          />
+
           <button
             onClick={() => onSelectOffer(merchant.seller_id)}
             disabled={loading}
@@ -275,10 +338,13 @@ function MerchantOfferCard({ merchant, amount, loading, isBest, onSelectOffer }:
           <span className="text-on-surface font-bold">${merchant.payout_mxn.toFixed(2)} MXN</span>
         </div>
       </div>
+      <EffectiveFeeNote
+        commissionPct={merchant.rate_percent}
+        platformFeePct={platformFeePct}
+        maxPct={maxEffectiveFeePercent}
+      />
       <div className="flex justify-between items-center border-t border-outline-variant/10 pt-4">
-        <p className="text-xs text-on-surface-variant">
-          Comisión {merchant.rate_percent}% · {distanceLabel}
-        </p>
+        <p className="text-xs text-on-surface-variant">{distanceLabel} de distancia</p>
         <button
           onClick={() => onSelectOffer(merchant.seller_id)}
           disabled={loading}
@@ -302,6 +368,7 @@ const DepositMap = ({
   creationErrorAction = 'retry',
   onDismissCreationError,
   onRetryCreationError,
+  maxEffectiveFeePercent = MAX_EFFECTIVE_FEE_PERCENT,
 }: DepositMapProps) => {
   const { state, refetch } = useMerchantsAvailable({
     amount_mxn: amount,
@@ -388,6 +455,7 @@ const DepositMap = ({
                 loading={loading}
                 isBest={idx === 0}
                 onSelectOffer={onSelectOffer}
+                maxEffectiveFeePercent={maxEffectiveFeePercent}
               />
             ))}
           </div>

--- a/micopay/frontend/src/pages/ExploreMap.tsx
+++ b/micopay/frontend/src/pages/ExploreMap.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import MapSim from '../components/MapSim';
 import { useMerchantsAvailable } from '../hooks/useMerchantsAvailable';
-import type { AvailableMerchant } from '../services/api';
+import {
+  effectiveFeePercent,
+  MAX_EFFECTIVE_FEE_PERCENT,
+  type AvailableMerchant,
+} from '../services/api';
+import { PLATFORM_FEE_PERCENT } from '../constants/trade';
 import ErrorBanner from '../components/ErrorBanner';
 import type { ApiErrorAction } from '../utils/apiError';
 
@@ -25,9 +30,13 @@ interface Offer {
   distance: string;
   walkMinutes: number;
   receiveMxn: number;
+  /** Provider commission (%). */
   commissionPct: number;
+  /** Platform fee (%) — the other half of the effective cost. */
+  platformFeePct: number;
   badge?: string;
   isPrimary?: boolean;
+  online?: boolean;
 }
 
 function merchantToOffer(m: AvailableMerchant, index: number): Offer {
@@ -39,6 +48,7 @@ function merchantToOffer(m: AvailableMerchant, index: number): Offer {
     walkMinutes: walkMinutes(m.distance_km),
     receiveMxn: m.payout_mxn,
     commissionPct: m.rate_percent,
+    platformFeePct: m.platform_fee_pct ?? PLATFORM_FEE_PERCENT,
     isPrimary: index === 0,
   };
 }
@@ -62,6 +72,51 @@ interface ExploreMapProps {
   creationErrorAction?: ApiErrorAction;
   onDismissCreationError?: () => void;
   onRetryCreationError?: () => void;
+  /** Effective-fee threshold (%) above which a warning is shown. Defaults to the shared guardrail. */
+  maxEffectiveFeePercent?: number;
+}
+
+// ─── Effective cost (provider + platform) + over-threshold warning ────────────
+
+function EffectiveFeeNote({
+  commissionPct,
+  platformFeePct,
+  maxPct,
+}: {
+  commissionPct: number;
+  platformFeePct: number;
+  maxPct: number;
+}) {
+  const totalPct = effectiveFeePercent(commissionPct, platformFeePct);
+  const exceeds = totalPct > maxPct;
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[11px] font-bold text-outline uppercase tracking-wider">
+          Costo total efectivo
+        </span>
+        <span
+          className={`text-sm font-bold tabular-nums ${exceeds ? 'text-error' : 'text-on-surface'}`}
+        >
+          {totalPct.toFixed(1)}%
+        </span>
+      </div>
+      <p className="text-[11px] text-outline font-medium">
+        Plataforma {platformFeePct}% + proveedor {commissionPct}%
+      </p>
+      {exceeds && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-xl border border-error/30 bg-error/5 px-3 py-2"
+        >
+          <span className="material-symbols-outlined text-error text-base leading-none">warning</span>
+          <p className="text-[12px] font-medium text-error leading-snug">
+            El costo total supera el {maxPct}%. Compara con otra oferta antes de continuar.
+          </p>
+        </div>
+      )}
+    </div>
+  );
 }
 
 const ExploreMap = ({
@@ -74,6 +129,7 @@ const ExploreMap = ({
   creationErrorAction = 'retry',
   onDismissCreationError,
   onRetryCreationError,
+  maxEffectiveFeePercent = MAX_EFFECTIVE_FEE_PERCENT,
 }: ExploreMapProps) => {
   const [selectedMerchantId, setSelectedMerchantId] = useState<string | null>(null);
   const selectedOfferRef = useRef<HTMLElement | null>(null);
@@ -209,6 +265,13 @@ const ExploreMap = ({
                           </p>
                         </div>
                       </div>
+                      <div className="mb-6 p-4 bg-white/50 rounded-2xl">
+                        <EffectiveFeeNote
+                          commissionPct={offer.commissionPct}
+                          platformFeePct={offer.platformFeePct}
+                          maxPct={maxEffectiveFeePercent}
+                        />
+                      </div>
                       <button
                         onClick={() => {
                           if (onProceedToConfirm) {
@@ -271,6 +334,13 @@ const ExploreMap = ({
                           ${offer.receiveMxn.toFixed(2)} MXN
                         </p>
                       </div>
+                    </div>
+                    <div className="mb-4">
+                      <EffectiveFeeNote
+                        commissionPct={offer.commissionPct}
+                        platformFeePct={offer.platformFeePct}
+                        maxPct={maxEffectiveFeePercent}
+                      />
                     </div>
                     <button
                       onClick={() => {

--- a/micopay/frontend/src/services/api.ts
+++ b/micopay/frontend/src/services/api.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { extractApiErrorPayload, toApiError } from '../utils/apiError';
 import { signChallenge, getPublicKey } from '../lib/keystore';
 import { removeKey } from './secureStorage';
+import { PLATFORM_FEE_PERCENT } from '../constants/trade';
 
 const BASE_URL = import.meta.env.VITE_API_URL ?? "http://localhost:3000";
 
@@ -464,6 +465,31 @@ export interface AvailableMerchant {
   distance_km: number;
   /** Payout the buyer receives for the requested amount. */
   payout_mxn: number;
+  /**
+   * Platform fee (%) for this merchant, if the backend ever returns a per-merchant
+   * value. Today the API does not send it, so consumers fall back to
+   * `PLATFORM_FEE_PERCENT`.
+   */
+  platform_fee_pct?: number;
+}
+
+/**
+ * Effective-fee guardrail. Validations V-1/V-3/V-7/V-8 found a universal ceiling:
+ * users abandon MicoPay when the *total* cost exceeds ~5%. The UI warns above this
+ * threshold. Kept here (not hardcoded in components) so it can be tuned centrally.
+ */
+export const MAX_EFFECTIVE_FEE_PERCENT = 5;
+
+/**
+ * Total effective cost the user pays = provider commission + platform fee.
+ * `platformPct` defaults to the shared `PLATFORM_FEE_PERCENT` constant because the
+ * `/merchants/available` response does not (yet) carry a per-merchant platform fee.
+ */
+export function effectiveFeePercent(
+  providerPct: number,
+  platformPct: number = PLATFORM_FEE_PERCENT,
+): number {
+  return providerPct + platformPct;
 }
 
 export interface MerchantsAvailableQuery {


### PR DESCRIPTION
Closes #192 

## Contexto

Las validaciones **V-1, V-3, V-7 y V-8** identificaron un techo universal: los
usuarios abandonan MicoPay cuando el **costo total** supera ~5%. Hasta ahora la UI
mostraba el fee de plataforma (0.8%) y la comisión del proveedor (`commissionPct`)
**por separado**, sin el total combinado ni una advertencia — y la comisión del
proveedor es justamente la parte más variable.


## Qué cambia

### `services/api.ts`
- `MAX_EFFECTIVE_FEE_PERCENT = 5` — umbral **configurable y centralizado** (no
  hardcodeado en los componentes).
- `effectiveFeePercent(providerPct, platformPct?)` — costo total = comisión del
  proveedor + fee de plataforma. `platformPct` cae a `PLATFORM_FEE_PERCENT` porque
  `/merchants/available` aún no envía un fee por comercio.
- Campo opcional `platform_fee_pct?` en `AvailableMerchant`, por si el backend lo
  expone en el futuro (fallback transparente a la constante).

### `pages/ExploreMap.tsx` y `pages/DepositMap.tsx`
- Cada tarjeta de proveedor muestra **"Costo total efectivo"** = `plataforma % + proveedor %`.
- **Advertencia visible** cuando el total supera el umbral, mostrada **antes de
  seleccionar la oferta**.
- Umbral inyectable vía prop `maxEffectiveFeePercent` (default `MAX_EFFECTIVE_FEE_PERCENT`),
  aplicado a ambas variantes de tarjeta (mejor oferta y ofertas secundarias).

### Fix incidental
- Corrige un error de tipo **preexistente en `main`** en `ExploreMap` (`Offer.online`
  no existía en la interfaz) que rompía `tsc`. Era necesario resolverlo para cumplir
  el criterio de aceptación de `tsc`.

## Criterios de aceptación

- [x] El usuario ve el **porcentaje total efectivo** (plataforma + proveedor), no solo el de plataforma.
- [x] Si el total supera ~5%, se muestra **advertencia visible antes de seleccionar** el proveedor.
- [x] El umbral del 5% es **constante o prop** — no está hardcodeado en el componente.
- [x] `tsc --noEmit` pasa **sin errores**.

## Pruebas

- `tsc --noEmit` → **sin errores**.
- Suite de tests: **sin regresiones nuevas**. El fallo de `TradeDetail.test.tsx`
  ya existe en `main` (verificado contra el baseline) y no está relacionado con este cambio.

## Archivos tocados

| Archivo | Cambio |
|---|---|
| `micopay/frontend/src/services/api.ts` | Constante de umbral, helper `effectiveFeePercent`, campo `platform_fee_pct?` |
| `micopay/frontend/src/pages/ExploreMap.tsx` | Costo total + advertencia en tarjeta (cashout) |
| `micopay/frontend/src/pages/DepositMap.tsx` | Costo total + advertencia en tarjeta (depósito) |

