### PR TITLE
docs(validation): add V-18 NFC / tap-to-pay familiarity & trust

### DIFF
--- a/docs/VALIDATION_DRIPS.md
+++ b/docs/VALIDATION_DRIPS.md
@@ -300,6 +300,20 @@ If the entire experience was smooth, secure, and exactly as the platform promise
 
 ---
 
+### V-18 · NFC / contactless tap-to-pay familiarity & trust
+**Contributor:** [@adepoju2006](https://github.com/adepoju2006) · **PR:** _(this PR)_
+
+_Wave 6 · batch 2 (V-16…V-25) · Validates Claim 4 + 6 — payment UX feasibility · Vertical B (Retail)_
+
+- **Country / general region:** West Africa (Nigeria).
+- **Have I used tap-to-pay (NFC) with a phone or card? How often?:** Rarely — "sometimes," and almost always with a contactless card rather than a phone. In daily life here the dominant rails are chip-and-PIN on POS terminals, instant bank transfers from a banking app, and USSD codes. Contactless terminals exist but are not the norm, so I don't reach for tap as a default; I only use it on the few modern terminals that clearly support it.
+- **Do I trust the tap more or less than a PIN, a QR scan, or cash? Why?:** Less than chip-and-PIN and less than a confirmed bank transfer, because both of those have an explicit "I approved this" moment (I enter a PIN, or I confirm an amount on my own screen). Tap completes so fast and so passively that it feels like nothing happened — there's no deliberate confirmation that I controlled. QR feels natural and trustworthy here because scan-to-transfer and USSD are already the everyday mental model. Cash I trust completely; it's just inconvenient and risky to carry.
+- **Has an NFC payment ever failed or felt uncertain?:** Yes. A tap once didn't register cleanly — the terminal gave an ambiguous beep and I couldn't tell if it went through. I was afraid that tapping again would charge me twice, so I just stood there unsure until the cashier checked their side. The core problem was the absence of a clear, immediate confirmation on *my* device.
+- **If a local shop accepted NFC from a "dollars" wallet, would tapping feel natural, or would I prefer QR?:** I would prefer to scan a QR. In this market QR/transfer is the established habit, and for a foreign-currency ("dollars") wallet I'd specifically want to *see* the merchant and confirm the details before approving — a QR flow shows me who I'm paying and lets me review on my own phone first. A blind tap into an unfamiliar dollar wallet would feel novel and a little risky.
+- **The single on-screen signal that would make me confident the payment succeeded:** An immediate, unmistakable success state on my own phone right after the tap: a green checkmark with the merchant's name and the paid amount, ideally accompanied by a short haptic buzz and my updated balance so I can see the funds actually moved. The confirmation has to be on my screen, not only on the merchant's terminal.
+
+---
+
 ## How findings feed Wave 6 product work
 
 - Cash-out vs cash-in vs remittance demand → which direction to prioritize first.


### PR DESCRIPTION
Closes #233 

**Wave 6 · Market & User Validation — batch 2 (V-16…V-25).** Continues V-1…V-15.

**Validates:** Claim 4 + 6 — payment UX feasibility · **Vertical:** B (Retail)

### Context
The retail flow in the vision uses NFC tap-to-pay. Before building it, we need to
know whether NFC is familiar and trusted in our target markets, or whether QR is
the more natural payment gesture. This PR adds a first-person, privacy-first data
point to that question.

### What this PR does
Adds a single `### V-18` section to `docs/VALIDATION_DRIPS.md` with my own
anonymized experience, following the established entry format (contributor/PR line
+ bulleted Q&A, consistent with V-13/V-14). No other files are touched.

### Summary of the response
- **Region:** West Africa (Nigeria), general only.
- **NFC usage:** Rare ("sometimes"), and almost always with a contactless *card*,
  not a phone — daily rails here are chip-and-PIN, instant bank transfer, and USSD.
- **Trust:** Lower than PIN / confirmed transfer because tap lacks an explicit
  "I approved this" moment; QR feels more natural locally.
- **Failure experience:** An ambiguous terminal beep with no confirmation on my own
  device, plus double-charge fear before re-tapping.
- **Tap vs QR for a "dollars" wallet:** Would prefer QR — to see the merchant and
  review details on my own phone before approving.
- **Confidence signal:** An immediate green checkmark on my own phone showing
  merchant name + amount, with haptic feedback and an updated balance.

### Privacy compliance 
No real names, phone numbers, addresses, wallet addresses, private keys, documents,
receipts, transaction hashes, or financial details. No money amounts or ranges.
Only a general country/region and my own anonymized experience.

### Files changed
| File | Change |
|---|---|
| `docs/VALIDATION_DRIPS.md` | Added `### V-18` section (inserted after V-15, before the closing "How findings feed Wave 6 product work") |

