### PR TITLE
docs: add SEC-23 security report - inconsistent token keys

### DIFF
--- a/docs/security-reports/SEC-23-token-keys-inconsistentes.md
+++ b/docs/security-reports/SEC-23-token-keys-inconsistentes.md
@@ -1,0 +1,19 @@
+# SEC-23: Claves de token inconsistentes entre módulos
+
+## Resultado
+El token de sesión se guarda correctamente en `micopay_users` vía `secureStorage`, pero otros módulos intentan leerlo de `localStorage` bajo claves diferentes (`auth_token`, `token`) que nunca se escriben.
+
+## Evidencia
+- `micopay/frontend/src/services/secureStorage.ts`: Usa `micopay_users`
+- `src/hooks/useChatMessages.ts:85,127,224`: `localStorage.getItem('auth_token')`
+- `src/utils/reportError.ts:17`: `localStorage.getItem('token')`
+- `src/pages/TradeDetail.tsx:27,36`: Posible uso de token inconsistente
+
+## Reproducible en testnet
+Sí — chat y reportError envían Authorization vacío.
+
+## Sugerencia de fix
+Unificar todo a `secureStorage.get('micopay_users')` y eliminar lecturas directas de `localStorage` para tokens.
+
+## Estado
+En progreso


### PR DESCRIPTION
## Summary
Added security report for inconsistent token keys across modules.

## Changes
- Added `docs/security-reports/SEC-23-token-keys-report.md`

## Related Issue
Closes #255