### PR TITLE
implementation for SEC-0

### DIFF
--- a/apps/api/src/__tests__/auth-rate-limit.test.ts
+++ b/apps/api/src/__tests__/auth-rate-limit.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Fastify from 'fastify';
+import fastifyJwt from '@fastify/jwt';
+import { registerRateLimit } from '../plugins/rate-limit.js';
+import { authRoutes } from '../routes/auth.js';
+
+const {
+  upsertChallengeMock,
+  getPendingChallengeMock,
+  consumeChallengeMock,
+  cleanupExpiredChallengesMock,
+  dbGetOneMock,
+} = vi.hoisted(() => ({
+  upsertChallengeMock: vi.fn(),
+  getPendingChallengeMock: vi.fn(),
+  consumeChallengeMock: vi.fn(),
+  cleanupExpiredChallengesMock: vi.fn(),
+  dbGetOneMock: vi.fn(),
+}));
+
+vi.mock('../db/auth.js', () => ({
+  upsertChallenge: upsertChallengeMock,
+  getPendingChallenge: getPendingChallengeMock,
+  consumeChallenge: consumeChallengeMock,
+  cleanupExpiredChallenges: cleanupExpiredChallengesMock,
+}));
+
+vi.mock('../db/schema.js', () => ({
+  default: {
+    getOne: dbGetOneMock,
+  },
+}));
+
+async function buildApp() {
+  const app = Fastify();
+  await app.register(fastifyJwt, { secret: 'test-secret' });
+  await registerRateLimit(app);
+  await app.register(authRoutes);
+  return app;
+}
+
+describe('auth route rate limiting', () => {
+  beforeEach(() => {
+    upsertChallengeMock.mockReset();
+    getPendingChallengeMock.mockReset();
+    consumeChallengeMock.mockReset();
+    cleanupExpiredChallengesMock.mockReset();
+    dbGetOneMock.mockReset();
+
+    upsertChallengeMock.mockResolvedValue(undefined);
+    cleanupExpiredChallengesMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 429 for repeated auth challenge requests after the per-route limit is exceeded', async () => {
+    const app = await buildApp();
+
+    const payload = { stellar_address: 'G'.repeat(56) };
+
+    for (let index = 0; index < 5; index += 1) {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/auth/challenge',
+        payload,
+      });
+
+      expect(response.statusCode).toBe(200);
+    }
+
+    const blocked = await app.inject({
+      method: 'POST',
+      url: '/auth/challenge',
+      payload,
+    });
+
+    expect(blocked.statusCode).toBe(429);
+    expect(blocked.json()).toMatchObject({ error: 'Too Many Requests' });
+
+    await app.close();
+  });
+});

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -9,6 +9,12 @@ import {
   cleanupExpiredChallenges,
 } from '../db/auth.js';
 
+const authRateLimitConfig = {
+  max: 5,
+  timeWindow: '1 minute',
+  keyGenerator: (request: { ip: string }) => request.ip,
+};
+
 export async function authRoutes(app: FastifyInstance & { jwt: any }) {
   /**
    * POST /auth/challenge
@@ -16,6 +22,9 @@ export async function authRoutes(app: FastifyInstance & { jwt: any }) {
    * Persisted to DB so it survives restarts and works across multiple instances.
    */
   app.post('/auth/challenge', {
+    config: {
+      rateLimit: authRateLimitConfig,
+    },
     schema: {
       body: {
         type: 'object',
@@ -48,6 +57,9 @@ export async function authRoutes(app: FastifyInstance & { jwt: any }) {
    * In production: verify using Stellar SDK's Keypair.verify().
    */
   app.post('/auth/token', {
+    config: {
+      rateLimit: authRateLimitConfig,
+    },
     schema: {
       body: {
         type: 'object',

--- a/docs/security-reports/SEC-04-rate-limit-global.md
+++ b/docs/security-reports/SEC-04-rate-limit-global.md
@@ -1,0 +1,22 @@
+# SEC-04: Rate limiting global no protege endpoints de autenticación
+
+## Resumen
+El servicio aplica un rate limit global de 100 solicitudes por minuto a toda la API mediante el plugin de Fastify. Ese límite compartido afectaba desproporcionadamente a los endpoints de autenticación, porque `POST /auth/challenge` y `POST /auth/token` no tenían una política propia que los aislara del resto del servicio.
+
+## Impacto
+- Un atacante podía agotar el bucket compartido con solicitudes repetidas a los endpoints de autenticación.
+- El bloqueo global podía afectar usuarios legítimos que intentaban usar otros endpoints de la API durante el mismo periodo.
+- La mitigación anterior no ofrecía granularidad ni aislamiento para los flujos de login y challenge.
+
+## Implementación realizada
+Se añadieron límites específicos por ruta y por IP para los endpoints de autenticación:
+- `POST /auth/challenge`
+- `POST /auth/token`
+
+La configuración se aplicó en el router de autenticación con un límite de 5 solicitudes por minuto por IP, usando el plugin de rate limiting de Fastify sobre las rutas afectadas.
+
+## Verificación
+Se añadió una prueba de regresión que valida que, tras exceder el límite por ruta, la API responde con `429 Too Many Requests` para solicitudes adicionales a `/auth/challenge`.
+
+## Severidad
+Media.


### PR DESCRIPTION
## Summary

This PR isolates authentication traffic from the shared global API rate limit by applying a dedicated per-IP limiter to the auth endpoints.

## What changed

- Added route-scoped rate limiting for:
  - POST /auth/challenge
  - POST /auth/token
- Configured the auth limiter to use a per-IP key so one abusive client does not exhaust the shared bucket for other users.
- Added a regression test to verify that repeated auth challenge requests return 429 once the route-specific limit is exceeded.
- Documented the security finding and mitigation in docs/security-reports/SEC-04-rate-limit-global.md

## Why

The previous setup relied on a global limit only, which allowed auth traffic to consume shared capacity and could cause collateral denial of service for legitimate users. This change ensures auth endpoints are protected independently.

## Verification

Verified with fresh test runs:
- npm --prefix apps/api test -- src/__tests__/auth-rate-limit.test.ts
- npm --prefix apps/api test -- src/__tests__/app.test.ts src/__tests__/demo.test.ts src/__tests__/auth-rate-limit.test.ts



Closes: #211 