### PR TITLE
[SEC-08] Make ZK Merkle root validation fatal on RPC failure

### DIFF
--- a/apps/api/src/__tests__/zk.test.ts
+++ b/apps/api/src/__tests__/zk.test.ts
@@ -1,8 +1,24 @@
-import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from "vitest";
 import Fastify, { FastifyInstance } from "fastify";
 import { zkRoutes } from "../routes/zk.js";
 
-// Stub all Soroban/network calls so tests run offline
+// Shared mock functions — defined with vi.hoisted() so they're accessible inside vi.mock()
+// (vi.mock() factories are hoisted before imports, so outer-scope let/const aren't ready yet).
+const mockGetAccount = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ accountId: () => "GTEST", incrementSequenceNumber: vi.fn() })
+);
+const mockSimulateTransaction = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ result: null })
+);
+const mockSendTransaction = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ status: "PENDING", hash: "aabbcc" })
+);
+const mockGetTransaction = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ status: "SUCCESS", returnValue: null })
+);
+
+// Stub all Soroban/network calls so tests run offline.
+// The Server class uses the shared hoisted mocks so per-test overrides work.
 vi.mock("@stellar/stellar-sdk", async (importOriginal: () => Promise<typeof import("@stellar/stellar-sdk")>) => {
   const actual = await importOriginal();
 
@@ -33,14 +49,13 @@ vi.mock("@stellar/stellar-sdk", async (importOriginal: () => Promise<typeof impo
     rpc: {
       ...actual.rpc,
       assembleTransaction: vi.fn().mockReturnValue(fakeBuilder),
+      // Each new Server() instance delegates to the shared hoisted mock fns,
+      // so tests can use mockResolvedValueOnce / mockRejectedValueOnce directly.
       Server: class {
-        getAccount = vi.fn().mockResolvedValue({ accountId: () => "GTEST", incrementSequenceNumber: vi.fn() });
-        simulateTransaction = vi.fn().mockResolvedValue({ result: null });
-        sendTransaction = vi.fn().mockResolvedValue({ status: "PENDING", hash: "aabbcc" });
-        getTransaction = vi.fn().mockResolvedValue({
-          status: "SUCCESS",
-          returnValue: actual.xdr.ScVal.scvBool(true),
-        });
+        getAccount = mockGetAccount;
+        simulateTransaction = mockSimulateTransaction;
+        sendTransaction = mockSendTransaction;
+        getTransaction = mockGetTransaction;
       },
       Api: {
         ...actual.rpc?.Api,
@@ -64,6 +79,18 @@ describe("ZK Routes", () => {
     await app.ready();
   });
 
+  beforeEach(() => {
+    // Reset shared mocks to safe defaults before each test to avoid state leakage.
+    mockGetAccount.mockReset();
+    mockGetAccount.mockResolvedValue({ accountId: () => "GTEST", incrementSequenceNumber: vi.fn() });
+    mockSimulateTransaction.mockReset();
+    mockSimulateTransaction.mockResolvedValue({ result: null });
+    mockSendTransaction.mockReset();
+    mockSendTransaction.mockResolvedValue({ status: "PENDING", hash: "aabbcc" });
+    mockGetTransaction.mockReset();
+    mockGetTransaction.mockResolvedValue({ status: "SUCCESS", returnValue: null });
+  });
+
   afterAll(async () => {
     await app.close();
   });
@@ -73,10 +100,11 @@ describe("ZK Routes", () => {
       const res = await app.inject({ method: "GET", url: "/api/v1/zk/circuits" });
       expect(res.statusCode).toBe(200);
       const body = JSON.parse(res.body);
-      expect(body.circuits).toHaveLength(2);
+      expect(body.circuits).toHaveLength(3);
       const ids = body.circuits.map((c: { circuit_id: string }) => c.circuit_id);
       expect(ids).toContain("poseidon_preimage");
       expect(ids).toContain("reputation_v1");
+      expect(ids).toContain("access_credential_v1");
     });
 
     it("includes payment info", async () => {
@@ -188,6 +216,7 @@ describe("ZK Routes", () => {
     });
 
     it("returns verified result for reputation_v1 with 4 inputs and mock payment", async () => {
+      // fetchReputationRoot: simulateTransaction returns { result: null } → root=null → check skipped
       const res = await app.inject({
         method: "POST",
         url: "/api/v1/zk/verify",
@@ -210,46 +239,19 @@ describe("ZK Routes", () => {
     });
 
     it("returns 400 when reputation_v1 merkle_root does not match on-chain root", async () => {
-      // Override the simulateTransaction mock for this test only so that
-      // fetchReputationRoot returns a specific known on-chain root,
-      // then submit a proof whose public_inputs[0] differs from that root.
-      //
-      // The top-level vi.mock already stubs rpc.Server; we override getTransaction
-      // globally to return FAILED for the root-fetch call by making simulateTransaction
-      // return a scvBytes value that represents root "99999999999999999999999999999".
-      //
-      // Simplest approach: use the route's own stale-root guard by providing a
-      // root that can never match (the global mock returns null for root fetch,
-      // so the guard is non-fatal). We test the guard logic by temporarily
-      // making fetchReputationRoot return a concrete value via module-level mock override.
-
-      // The existing global mock makes simulateTransaction return { result: null },
-      // so fetchReputationRoot returns null and the guard is skipped (non-fatal per spec).
-      // To test the guard: override to return a specific on-chain root.
-
-      // We use vi.doMock to change the rpc.Server behavior for this call:
-      // Temporarily patch the module-level rpc.Server mock to return a root value.
+      // Make fetchReputationRoot() return a concrete on-chain root by having
+      // simulateTransaction return a scvBytes ScVal on the first call.
       const StellarModule = await import("@stellar/stellar-sdk");
-      const originalSimulate = StellarModule.rpc.Server.prototype.simulateTransaction;
 
       const onChainRootDec = "99999999999999999999999999999";
       const onChainRootHex = BigInt(onChainRootDec).toString(16).padStart(64, "0");
       const onChainRootBuf = Buffer.from(onChainRootHex, "hex");
 
-      // Patch: first call to simulateTransaction returns the on-chain root
-      let callCount = 0;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (StellarModule.rpc.Server.prototype as any).simulateTransaction = vi.fn().mockImplementation(async () => {
-        callCount++;
-        if (callCount === 1) {
-          // root fetch call
-          return {
-            result: { retval: StellarModule.xdr.ScVal.scvBytes(onChainRootBuf) },
-          };
-        }
-        // verify call — return a normal success
-        return { result: null };
+      // First call: fetchReputationRoot → return the on-chain root
+      mockSimulateTransaction.mockResolvedValueOnce({
+        result: { retval: StellarModule.xdr.ScVal.scvBytes(onChainRootBuf) },
       });
+      // Subsequent calls (invokeVerify) use the default { result: null }
 
       const res = await app.inject({
         method: "POST",
@@ -267,13 +269,76 @@ describe("ZK Routes", () => {
         },
       });
 
-      // Restore
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (StellarModule.rpc.Server.prototype as any).simulateTransaction = originalSimulate;
-
       expect(res.statusCode).toBe(400);
       const body = JSON.parse(res.body);
       expect(body.error).toMatch(/merkle_root/);
+    });
+
+    // SEC-08 — Fatal Merkle root guard: RPC failure must reject with 503, not silently pass through.
+    // Before the fix the catch block was non-fatal and a fabricated root could bypass the check
+    // during an RPC outage window.
+    it("returns 503 for reputation_v1 when RPC is unreachable (SEC-08 fatal guard)", async () => {
+      mockGetAccount.mockRejectedValueOnce(new Error("ECONNREFUSED: RPC endpoint unreachable"));
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/zk/verify",
+        headers: { "x-payment": MOCK_PAYMENT_HEADER },
+        payload: {
+          circuit_id: "reputation_v1",
+          proof: VALID_PROOF_B64,
+          public_inputs: [
+            "99999999999999999999999", // fabricated root — would bypass check if non-fatal
+            "2",
+            "333333333333333333333333",
+            "444444444444444444444444",
+          ],
+        },
+      });
+
+      expect(res.statusCode).toBe(503);
+      const body = JSON.parse(res.body);
+      expect(body.error).toMatch(/Merkle root/);
+    });
+
+    it("returns 503 for access_credential_v1 when RPC is unreachable (SEC-08 fatal guard)", async () => {
+      mockGetAccount.mockRejectedValueOnce(new Error("Request timeout"));
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/zk/verify",
+        headers: { "x-payment": MOCK_PAYMENT_HEADER },
+        payload: {
+          circuit_id: "access_credential_v1",
+          proof: VALID_PROOF_B64,
+          public_inputs: [
+            "99999999999999999999999", // fabricated root
+            "444444444444444444444444",
+          ],
+        },
+      });
+
+      expect(res.statusCode).toBe(503);
+      const body = JSON.parse(res.body);
+      expect(body.error).toMatch(/Merkle root/);
+    });
+
+    it("poseidon_preimage is unaffected by RPC failure (no Merkle root check)", async () => {
+      // poseidon_preimage is NOT in ROOTED_CIRCUITS, so fetchReputationRoot is never
+      // called. Even if the RPC were down for the root fetch, the circuit should succeed.
+      // (In this test the mocks are healthy, verifying that no extraneous root fetch occurs.)
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/zk/verify",
+        headers: { "x-payment": MOCK_PAYMENT_HEADER },
+        payload: {
+          circuit_id: "poseidon_preimage",
+          proof: VALID_PROOF_B64,
+          public_inputs: ["9876543210123456789"],
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
     });
 
     // Replay attack: same proof submitted twice → second must be rejected (409).
@@ -303,11 +368,7 @@ describe("ZK Routes", () => {
 
       // Second submission — contract rejects; getTransaction returns FAILED
       // with error detail "Error(Contract, #10)" in the result XDR
-      const StellarModule = await import("@stellar/stellar-sdk");
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const origGetTx = (StellarModule.rpc.Server.prototype as any).getTransaction;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (StellarModule.rpc.Server.prototype as any).getTransaction = vi.fn().mockResolvedValueOnce({
+      mockGetTransaction.mockResolvedValueOnce({
         status: "FAILED",
         resultMetaXdr: "Error(Contract, #10)",
       });
@@ -317,8 +378,6 @@ describe("ZK Routes", () => {
         headers: { "x-payment": MOCK_PAYMENT_HEADER },
         payload,
       });
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (StellarModule.rpc.Server.prototype as any).getTransaction = origGetTx;
 
       expect(second.statusCode).toBe(409);
       expect(JSON.parse(second.body).error).toMatch(/Nullifier already used/);

--- a/apps/api/src/routes/zk.ts
+++ b/apps/api/src/routes/zk.ts
@@ -169,6 +169,9 @@ export async function zkRoutes(fastify: FastifyInstance): Promise<void> {
 
       // 6. For rooted circuits: cross-check public_inputs[0] (merkle_root) against
       //    the published on-chain root so a prover can't use a fabricated root.
+      //    SEC-08: RPC failure is FATAL — a silently-skipped root check opens a
+      //    window where an attacker can submit a proof with a fabricated root while
+      //    the RPC is unreachable. Reject with 503 instead of letting the proof through.
       if (ROOTED_CIRCUITS.has(circuit_id)) {
         try {
           const onChainRoot = await fetchReputationRoot();
@@ -179,8 +182,10 @@ export async function zkRoutes(fastify: FastifyInstance): Promise<void> {
             });
           }
         } catch (err) {
-          // Non-fatal if root unavailable — let contract decide
-          fastify.log.warn({ err }, "Could not fetch on-chain root");
+          fastify.log.error({ err }, "Could not fetch on-chain root — rejecting request to prevent fabricated-root attack");
+          return reply.status(503).send({
+            error: "Cannot verify Merkle root: on-chain root unavailable. Try again later.",
+          });
         }
       }
 
@@ -227,39 +232,40 @@ export async function zkRoutes(fastify: FastifyInstance): Promise<void> {
   });
 }
 
-// Fetch current reputation root from ZK contract
+// Fetch current reputation root from ZK contract.
+// Returns null when the contract has no root set or the contract ID is unconfigured.
+// Throws on RPC/network errors so the caller can treat unavailability as fatal (SEC-08).
 async function fetchReputationRoot(): Promise<string | null> {
   const contractId = process.env.ZK_VERIFIER_CONTRACT_ID ?? "";
   if (!contractId) return null;
-  try {
-    const rpc = new StellarSdk.rpc.Server(RPC_URL);
-    const signerKP = StellarSdk.Keypair.fromSecret(
-      process.env.ADMIN_SECRET_KEY ?? ""
-    );
-    const account = await rpc.getAccount(signerKP.publicKey());
-    const contract = new StellarSdk.Contract(contractId);
 
-    const tx = new StellarSdk.TransactionBuilder(account, {
-      fee: "100",
-      networkPassphrase: NET,
-    })
-      .addOperation(contract.call("get_reputation_root"))
-      .setTimeout(30)
-      .build();
+  // No try-catch here — network failures propagate so the route handler can reject
+  // the request rather than silently skipping the Merkle root check.
+  const rpc = new StellarSdk.rpc.Server(RPC_URL);
+  const signerKP = StellarSdk.Keypair.fromSecret(
+    process.env.ADMIN_SECRET_KEY ?? ""
+  );
+  const account = await rpc.getAccount(signerKP.publicKey());
+  const contract = new StellarSdk.Contract(contractId);
 
-    const sim = await rpc.simulateTransaction(tx);
-    if (StellarSdk.rpc.Api.isSimulationError(sim)) return null;
+  const tx = new StellarSdk.TransactionBuilder(account, {
+    fee: "100",
+    networkPassphrase: NET,
+  })
+    .addOperation(contract.call("get_reputation_root"))
+    .setTimeout(30)
+    .build();
 
-    const ret = (sim as StellarSdk.rpc.Api.SimulateTransactionSuccessResponse).result?.retval;
-    if (!ret) return null;
-    // Contract returns Result<Bytes, Error> — extract Ok(bytes) value
-    // ScVal is scvVec with first element being the discriminant for Ok
-    if (ret.switch().name === "scvBytes") {
-      const buf = ret.bytes();
-      return BigInt("0x" + Buffer.from(buf).toString("hex")).toString();
-    }
-    return null;
-  } catch {
-    return null;
+  const sim = await rpc.simulateTransaction(tx);
+  if (StellarSdk.rpc.Api.isSimulationError(sim)) return null;
+
+  const ret = (sim as StellarSdk.rpc.Api.SimulateTransactionSuccessResponse).result?.retval;
+  if (!ret) return null;
+  // Contract returns Result<Bytes, Error> — extract Ok(bytes) value
+  // ScVal is scvVec with first element being the discriminant for Ok
+  if (ret.switch().name === "scvBytes") {
+    const buf = ret.bytes();
+    return BigInt("0x" + Buffer.from(buf).toString("hex")).toString();
   }
+  return null;
 }

--- a/docs/security-reports/SEC-08-zk-merkle-root-no-fatal.md
+++ b/docs/security-reports/SEC-08-zk-merkle-root-no-fatal.md
@@ -1,0 +1,136 @@
+# SEC-08 — ZK Merkle Root Validation Non-Fatal: Fabricated Root Attack Window
+
+**Severity:** 🟡 Medium  
+**Status:** Fixed  
+**Affected file:** `apps/api/src/routes/zk.ts` (lines 172–185 in the pre-fix version)  
+**Reporter:** Security audit — Wave 6  
+
+---
+
+## Summary
+
+The API's pre-flight Merkle root check for `reputation_v1` and `access_credential_v1`
+circuits was wrapped in a non-fatal `try/catch`. When `fetchReputationRoot()` threw
+(e.g., the Soroban RPC endpoint was unreachable), the error was silently swallowed and
+the proof was forwarded to the contract without any root verification. An attacker who
+could force or predict a brief RPC outage could exploit this window to submit a proof
+built against an arbitrary, fabricated Merkle root.
+
+---
+
+## Reproduction Steps
+
+1. Generate a valid UltraHonk proof for `reputation_v1` using an **arbitrary** Merkle
+   root (not the one currently published on-chain).
+2. Block or timeout the Soroban RPC endpoint (local firewall rule, DNS poisoning, or
+   a transient outage).
+3. Submit the verification request during the outage window.
+4. Observe the API returning `verified: true` — the fabricated root was never checked.
+
+---
+
+## Does the Soroban contract have its own Merkle root guard?
+
+**No.** After reviewing `contracts/zk-verifier/src/lib.rs`, neither `verify` nor
+`verify_unique` compare `public_inputs[0]` against the on-chain `REP_ROOT` storage key.
+The contract only:
+
+- Looks up the circuit's verification key (`VK_MAP`).
+- Runs cryptographic UltraHonk verification.
+- Records the nullifier to prevent replay (`verify_unique` only).
+
+The Merkle root cross-check exists **exclusively in the API layer**. Therefore the
+non-fatal catch in the API directly corresponds to a security gap with no contract-level
+backstop.
+
+---
+
+## Impact
+
+| Scenario | Pre-fix | Post-fix |
+|---|---|---|
+| RPC up, root matches | ✅ Accepted | ✅ Accepted |
+| RPC up, root mismatch | ❌ Rejected (400) | ❌ Rejected (400) |
+| RPC down | ⚠️ **Silently accepted** | ❌ Rejected (503) |
+| No root configured (`contractId` unset) | ✅ Accepted (no root to check) | ✅ Accepted (no root to check) |
+
+An attacker exploiting the RPC-down window could forge reputation credentials,
+bypass access gates, or inflate on-chain reputation without holding a valid
+leaf in the actual Merkle tree.
+
+---
+
+## Root Cause
+
+`fetchReputationRoot()` wrapped all RPC calls in a `try/catch` that returned `null`
+on any error. The calling code in the route handler treated `null` as "root not
+configured, skip check" — the same branch used for an intentionally unconfigured
+contract. A transient network failure was indistinguishable from a deliberate
+non-configuration.
+
+The outer `try/catch` in the route handler was therefore never reached for
+`fetchReputationRoot()` failures; it had a misleading comment:
+
+```ts
+} catch (err) {
+  // Non-fatal if root unavailable — let contract decide  ← the contract does NOT decide
+  fastify.log.warn({ err }, "Could not fetch on-chain root");
+}
+```
+
+---
+
+## Fix Applied
+
+**`apps/api/src/routes/zk.ts`**
+
+1. Removed the `try/catch` from `fetchReputationRoot()` so RPC failures propagate
+   as thrown exceptions rather than silent `null` returns.
+
+2. Changed the route handler's catch block from a non-fatal warning to a fatal
+   **503 Service Unavailable** response:
+
+```ts
+} catch (err) {
+  fastify.log.error({ err }, "Could not fetch on-chain root — rejecting request to prevent fabricated-root attack");
+  return reply.status(503).send({
+    error: "Cannot verify Merkle root: on-chain root unavailable. Try again later.",
+  });
+}
+```
+
+`fetchReputationRoot()` still returns `null` (non-throwing) when the contract ID is
+not configured (`ZK_VERIFIER_CONTRACT_ID` unset) or when the contract itself signals
+"root not set" via a simulation error — neither case indicates an attack window.
+
+---
+
+## Tests Added
+
+`apps/api/src/__tests__/zk.test.ts` — three new test cases:
+
+- **`returns 503 for reputation_v1 when RPC is unreachable (SEC-08 fatal guard)`**
+- **`returns 503 for access_credential_v1 when RPC is unreachable (SEC-08 fatal guard)`**
+- **`poseidon_preimage is unaffected by RPC failure (no Merkle root check)`**
+
+---
+
+## Recommendation: Contract-level Guard
+
+For defence-in-depth, add a Merkle root check inside `verify` / `verify_unique` for
+rooted circuits in `contracts/zk-verifier/src/lib.rs`:
+
+```rust
+// Inside verify() for reputation_v1 and access_credential_v1
+let on_chain_root = env.storage().instance()
+    .get(&ROOT_KEY)
+    .ok_or(ZkError::ReputationRootNotSet)?;
+// public_inputs[0..32] must equal on_chain_root
+let proof_root = Bytes::from_slice(&env, &raw_inputs[0..32]);
+if proof_root != on_chain_root {
+    return Err(ZkError::VerificationFailed);
+}
+```
+
+This would make the guard redundant at both layers and eliminate the dependency on
+API-layer availability for this security property.


### PR DESCRIPTION
## Summary

Closes #215

This PR fixes the security vulnerability identified in **SEC-08**: the Merkle root pre-flight check for ZK proof verification in `apps/api/src/routes/zk.ts` was non-fatal — when the Soroban RPC endpoint was unreachable, the error was silently swallowed and the proof was forwarded to the contract without any root validation.

After investigation, the Soroban contract (`contracts/zk-verifier/src/lib.rs`) was confirmed to have **no duplicate Merkle root guard** — neither `verify` nor `verify_unique` compare `public_inputs[0]` against the on-chain `REP_ROOT` key. The check exists exclusively in the API layer, making the non-fatal catch a direct security gap with no backstop.

---

## Root Cause

`fetchReputationRoot()` wrapped all RPC calls in a `try/catch` that returned `null` on any error. The route handler treated `null` identically to "root not configured" — skipping the check in both cases:

```ts
// BEFORE (vulnerable)
} catch (err) {
  // Non-fatal if root unavailable — let contract decide  ← contract does NOT decide
  fastify.log.warn({ err }, "Could not fetch on-chain root");
}
// proof forwarded to contract with unverified merkle root
```

An attacker who could force or predict a brief RPC outage could present a valid UltraHonk proof built against an **arbitrary fabricated Merkle root** and receive `verified: true`.

---

## Changes

### `apps/api/src/routes/zk.ts`

- **Removed the `try/catch` from `fetchReputationRoot()`** so RPC/network errors propagate as thrown exceptions instead of being silently absorbed as `null` returns. The function still returns `null` (non-throwing) for the two legitimate non-error cases: `ZK_VERIFIER_CONTRACT_ID` not configured, and the contract signalling "root not set" via a simulation error.

- **Changed the route handler catch block from non-fatal to fatal** — returns `503 Service Unavailable` when the on-chain root cannot be fetched for a rooted circuit (`reputation_v1`, `access_credential_v1`), instead of logging a warning and passing the proof through:

```ts
// AFTER (fixed)
} catch (err) {
  fastify.log.error({ err }, "Could not fetch on-chain root — rejecting request to prevent fabricated-root attack");
  return reply.status(503).send({
    error: "Cannot verify Merkle root: on-chain root unavailable. Try again later.",
  });
}
```

### `apps/api/src/__tests__/zk.test.ts`

- **Restructured the Stellar SDK mock** to use `vi.hoisted()` shared mock functions instead of per-instance class field `vi.fn()` assignments. The old approach made prototype-patching inoperative (class fields shadow the prototype), so prior per-test mock overrides were silently ignored and two existing tests were broken. With `vi.hoisted()`, all mock functions are shared references that any test can control via `mockResolvedValueOnce` / `mockRejectedValueOnce`.

- **Added `beforeEach` reset** of all shared mock functions to safe defaults, preventing state leakage between tests.

- **Three new tests covering SEC-08:**
  - `returns 503 for reputation_v1 when RPC is unreachable (SEC-08 fatal guard)` — `getAccount` throws; expects 503 with a Merkle-root error message.
  - `returns 503 for access_credential_v1 when RPC is unreachable (SEC-08 fatal guard)` — same for the other rooted circuit.
  - `poseidon_preimage is unaffected by RPC failure (no Merkle root check)` — confirms non-rooted circuits are not affected by the fatal guard.

- **Fixed the existing `returns 400 when reputation_v1 merkle_root does not match` test** — updated to use `mockSimulateTransaction.mockResolvedValueOnce()` (which now works via the shared mock) instead of the broken prototype-patching approach.

- **Updated circuit count assertion** from `toHaveLength(2)` to `toHaveLength(3)` and added `access_credential_v1` to the expected id list, which was missing.

### `docs/security-reports/SEC-08-zk-merkle-root-no-fatal.md` _(new file)_

Full security report as requested in the issue, covering:
- Vulnerability description and reproduction steps
- Contract analysis confirming no duplicate root guard exists
- Impact matrix (RPC up/down × root match/mismatch)
- Root cause explanation
- Fix description
- Recommendation for defence-in-depth: add a Merkle root guard inside the Soroban contract's `verify`/`verify_unique` functions

---

## Test Results

All ZK route tests pass (14 passing, 1 skipped — the replay/409 test remains skipped pending WP4 contract redeploy as noted in the existing codebase). Pre-existing `merchant` and `p2p` test failures are unrelated (require a live PostgreSQL instance).

```
✓ GET /api/v1/zk/circuits > returns circuit list without payment
✓ GET /api/v1/zk/circuits > includes payment info
✓ POST /api/v1/zk/verify > returns 402 without payment header
✓ POST /api/v1/zk/verify > returns 400 for unknown circuit_id
✓ POST /api/v1/zk/verify > returns 400 for wrong number of public_inputs (poseidon_preimage needs 1)
✓ POST /api/v1/zk/verify > returns 400 for wrong number of public_inputs (reputation_v1 needs 4)
✓ POST /api/v1/zk/verify > returns 400 for non-decimal public_input
✓ POST /api/v1/zk/verify > returns 400 for empty proof
✓ POST /api/v1/zk/verify > returns verified result for poseidon_preimage with mock payment
✓ POST /api/v1/zk/verify > returns verified result for reputation_v1 with 4 inputs and mock payment
✓ POST /api/v1/zk/verify > returns 400 when reputation_v1 merkle_root does not match on-chain root
✓ POST /api/v1/zk/verify > returns 503 for reputation_v1 when RPC is unreachable (SEC-08 fatal guard)
✓ POST /api/v1/zk/verify > returns 503 for access_credential_v1 when RPC is unreachable (SEC-08 fatal guard)
✓ POST /api/v1/zk/verify > poseidon_preimage is unaffected by RPC failure (no Merkle root check)
↓ POST /api/v1/zk/verify > returns 409 on replay (skipped — requires WP4 redeploy)
```

---

## Severity

🟡 **Medium** — exploitable only during an RPC outage window, and only if the contract also lacks the check (confirmed it does). Recommended follow-up: add a contract-level Merkle root guard for defence-in-depth (see security report).