### PR TITLE
fix(frontend): validate HTLC secret/htlc format in QR parser — SEC-30 (#262)

### DIFF
--- a/docs/security-reports/SEC-30-qr-parser-secret.md
+++ b/docs/security-reports/SEC-30-qr-parser-secret.md
@@ -1,0 +1,98 @@
+# SEC-30 — QR parser: secret/htlc format validation & legacy scheme
+
+**Issue:** [#262](https://github.com/ericmt-98/micopay-protocol/issues/262)  
+**Archivo:** `micopay/frontend/src/utils/qrPayload.ts` (+ `demoMode.ts`, `qrValidation.ts`)  
+**Investigador:** @ironhood  
+**Fecha:** 2026-06-29  
+**Entorno:** micopay-frontend (Vite + Capacitor), testnet build, análisis estático + `vitest`
+
+---
+
+## Resultado
+
+**Vulnerabilidad confirmada (severidad media).** Antes del fix, `parseQRPayload` aceptaba `secret` y `htlc` sin validar formato ni longitud, y el esquema legacy `MICOPAY:` en texto plano seguía activo en builds de release. Se implementó validación estricta y se restringió el formato legacy a `VITE_DEMO_MODE=true`.
+
+| Pregunta | Respuesta |
+|----------|-----------|
+| ¿Se valida el formato de `secret`/`htlc`? | **Sí (post-fix).** `secret` debe ser hex de 64 caracteres (preimage HTLC de 32 bytes). `htlc` debe ser hash hex de 64 caracteres (tx Stellar) o prefijo `demo_htlc_` solo en demo mode. `trade_id` debe ser UUID; `request_id` alfanumérico con guiones. |
+| ¿El preimage HTLC se filtra a logs/clipboard/historial? | **No a logcat/console en código de producción.** No hay `console.log` del secret en el frontend. El QR vive en estado React (`QRReveal`, `ClaimQR`) mientras se muestra — comportamiento inherente al flujo QR. No hay copia automática al portapapeles del secret HTLC. El historial del WebView no persiste el payload del QR en rutas revisadas. |
+| ¿El formato legacy en claro sigue aceptándose en release? | **No (post-fix).** `MICOPAY:…` se rechaza cuando `VITE_DEMO_MODE !== 'true'`. |
+| ¿Demo secret aislado a `IS_DEMO_MODE`? | **Sí.** `DEMO_QR_PAYLOAD` solo se expone vía `getDemoQrPayload()` (lanza fuera de demo). Usado en `QRReveal.tsx` únicamente cuando `getSecret` falla **y** `IS_DEMO_MODE`. `App.tsx` stub de trade demo también gated por `IS_DEMO_MODE`. |
+
+---
+
+## Evidencia
+
+### 1. Reproducción pre-fix (acepta secret malformado)
+
+Entrada: `micopay://release?trade_id=abc-123&secret=ZZZ`
+
+Comportamiento anterior: `{ ok: true, payload: { type: 'release', tradeId: 'abc-123', secret: 'ZZZ' } }` — aceptaba cualquier string.
+
+Comportamiento post-fix: `{ ok: false, error: '…64 caracteres…' }` o error de UUID según el campo inválido.
+
+Tests automatizados en `micopay/frontend/src/utils/qrPayload.test.ts`:
+
+```bash
+cd micopay/frontend && npm test -- qrPayload qrValidation
+```
+
+### 2. Formato legacy `MICOPAY:` en release
+
+- Pre-fix: `parseQRPayload('MICOPAY:DEMO:mock_secret_for_ui_preview')` → `{ ok: true, type: 'demo' }` en cualquier build.
+- Post-fix: mismo input en release → `{ ok: false, error: '…legacy MICOPAY…' }`.
+- Demo build (`VITE_DEMO_MODE=true`): sigue aceptando el formato para previews UI.
+
+### 3. Filtrado del secret HTLC
+
+| Vector | Hallazgo |
+|--------|----------|
+| **logcat / console** | Búsqueda en `micopay/frontend/src`: ningún `console.log/debug/info` incluye `secret`, `qrPayload` ni el preimage HTLC. Los logs de push/offline queue no tocan material HTLC. |
+| **Estado WebView / React** | `QRReveal.tsx` guarda `qrPayload` en `useState` para renderizar el QR SVG. Se descarta al desmontar la pantalla. No se escribe en `localStorage`/`sessionStorage` ni en `secureStorage`. |
+| **Portapapeles** | No hay `navigator.clipboard.writeText` del secret HTLC ni del QR payload. Clipboard en la app se usa para claves Stellar del usuario (`Profile.tsx`, `Register.tsx`) y recibos (`SuccessScreen.tsx`) — flujos separados. |
+| **Historial de navegación** | Rutas React Router no incluyen query params con secret. Deep links `micopay://` se parsean en memoria en `MerchantInbox.handleScan`; solo se extrae `tradeId` para `merchantConfirmScan` — el secret parseado no se propaga más allá del objeto local `parsed`. |
+| **Backend e2e script** | `micopay/scripts/e2e-test.ts` imprime `qr_payload` en consola — script de desarrollo, no incluido en el APK. |
+
+### 4. Aislamiento demo (`demoMode.ts`)
+
+```typescript
+// demoMode.ts — getDemoQrPayload() throws outside demo mode
+// QRReveal.tsx:42 — fallback solo si IS_DEMO_MODE && getSecret() falla
+// App.tsx:753 — trade stub demo solo si IS_DEMO_MODE
+```
+
+Build prod (`build:prod`) no define `VITE_DEMO_MODE`; valor por defecto `false`.
+
+---
+
+## Reproducible en testnet
+
+**Sí.** El flujo release/claim con QR `micopay://` es el usado en testnet. La validación aplica igual en testnet y prod; el formato legacy solo en builds con `VITE_DEMO_MODE=true`.
+
+---
+
+## Sugerencia de fix (implementada en este PR)
+
+1. **`qrValidation.ts`** — helpers `isHex64`, `isUuid`, `isRequestId`, `isHtlcReference`.
+2. **`qrPayload.ts`** — rechazar `secret`/`htlc`/`trade_id` malformados; legacy `MICOPAY:` solo con `IS_DEMO_MODE`.
+3. **`demoMode.ts`** — `getDemoQrPayload()` con guard runtime; `QRReveal.tsx` actualizado.
+4. **Tests** — casos negativos para secret `ZZZ`, UUID inválido, htlc `0xhash`, legacy en release.
+
+### Follow-ups opcionales (fuera de scope)
+
+- **SEC-02/SEC-07:** auditar que el backend no devuelva el secret en logs de acceso (`secret_access_log` ya registra acceso sin el valor).
+- **MerchantInbox:** hoy solo usa `tradeId` del QR release; considerar ignorar el param `secret` en el flujo merchant (el backend valida on-chain).
+- **Capacitor WebView:** deshabilitar screenshot en pantalla QR (`FLAG_SECURE` en Android) — hardening adicional P2.
+
+---
+
+## Archivos modificados
+
+| Archivo | Cambio |
+|---------|--------|
+| `micopay/frontend/src/utils/qrValidation.ts` | Nuevo — validadores de formato |
+| `micopay/frontend/src/utils/qrPayload.ts` | Validación en parser |
+| `micopay/frontend/src/utils/demoMode.ts` | Guard `getDemoQrPayload()` |
+| `micopay/frontend/src/pages/QRReveal.tsx` | Usa `getDemoQrPayload()` |
+| `micopay/frontend/src/utils/qrPayload.test.ts` | Tests ampliados |
+| `micopay/frontend/src/utils/qrValidation.test.ts` | Tests de validadores |

--- a/micopay/frontend/src/pages/QRReveal.tsx
+++ b/micopay/frontend/src/pages/QRReveal.tsx
@@ -5,7 +5,7 @@ import { getTradeStateDebugOverride, normalizeTradeState, TradeState } from '../
 import ErrorBanner from '../components/ErrorBanner';
 import SupportLink from '../components/SupportLink';
 import { mapApiError, type MappedApiError } from '../utils/apiError';
-import { DEMO_QR_PAYLOAD, IS_DEMO_MODE } from '../utils/demoMode';
+import { getDemoQrPayload, IS_DEMO_MODE } from '../utils/demoMode';
 
 interface QRRevealProps {
     activeTrade: TradeData | null;
@@ -39,7 +39,7 @@ const QRReveal = ({ activeTrade, sellerToken, buyerToken, amount, onBack, onChat
             })
             .catch((e) => {
                 if (IS_DEMO_MODE) {
-                    setQrPayload(DEMO_QR_PAYLOAD);
+                    setQrPayload(getDemoQrPayload());
                     setSecretLoaded(true);
                 } else {
                     setSecretError(mapApiError(e));

--- a/micopay/frontend/src/utils/demoMode.ts
+++ b/micopay/frontend/src/utils/demoMode.ts
@@ -1,3 +1,12 @@
 export const IS_DEMO_MODE = import.meta.env.VITE_DEMO_MODE === 'true';
 
+/** Static QR shown when the backend is unreachable — demo builds only. */
 export const DEMO_QR_PAYLOAD = 'MICOPAY:DEMO:mock_secret_for_ui_preview';
+
+/** Returns the demo QR payload or throws if called outside demo mode. */
+export function getDemoQrPayload(): string {
+  if (!IS_DEMO_MODE) {
+    throw new Error('Demo QR payload is only available when VITE_DEMO_MODE=true');
+  }
+  return DEMO_QR_PAYLOAD;
+}

--- a/micopay/frontend/src/utils/qrPayload.test.ts
+++ b/micopay/frontend/src/utils/qrPayload.test.ts
@@ -1,24 +1,38 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { parseQRPayload } from './qrPayload';
+
+const TRADE_ID = '550e8400-e29b-41d4-a716-446655440000';
+const SECRET_64 = 'deadbeef'.repeat(8);
+const HTLC_TX_HASH = 'a'.repeat(64);
 
 describe('parseQRPayload', () => {
   // ── Release format ─────────────────────────────────────────────────────
   describe('micopay://release', () => {
     it('parses a valid release QR', () => {
-      const raw = 'micopay://release?trade_id=abc-123&secret=deadbeef';
+      const raw = `micopay://release?trade_id=${TRADE_ID}&secret=${SECRET_64}`;
       const result = parseQRPayload(raw);
       expect(result.ok).toBe(true);
       if (result.ok) {
         expect(result.payload.type).toBe('release');
         if (result.payload.type === 'release') {
-          expect(result.payload.tradeId).toBe('abc-123');
-          expect(result.payload.secret).toBe('deadbeef');
+          expect(result.payload.tradeId).toBe(TRADE_ID);
+          expect(result.payload.secret).toBe(SECRET_64);
         }
       }
     });
 
+    it('normalizes secret hex to lowercase', () => {
+      const upperSecret = 'DEADBEEF'.repeat(8);
+      const raw = `micopay://release?trade_id=${TRADE_ID}&secret=${upperSecret}`;
+      const result = parseQRPayload(raw);
+      expect(result.ok).toBe(true);
+      if (result.ok && result.payload.type === 'release') {
+        expect(result.payload.secret).toBe(SECRET_64);
+      }
+    });
+
     it('returns error when trade_id is missing', () => {
-      const raw = 'micopay://release?secret=deadbeef';
+      const raw = `micopay://release?secret=${SECRET_64}`;
       const result = parseQRPayload(raw);
       expect(result.ok).toBe(false);
       if (!result.ok) {
@@ -26,12 +40,30 @@ describe('parseQRPayload', () => {
       }
     });
 
+    it('returns error when trade_id is not a UUID', () => {
+      const raw = `micopay://release?trade_id=abc-123&secret=${SECRET_64}`;
+      const result = parseQRPayload(raw);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain('UUID');
+      }
+    });
+
     it('returns error when secret is missing', () => {
-      const raw = 'micopay://release?trade_id=abc-123';
+      const raw = `micopay://release?trade_id=${TRADE_ID}`;
       const result = parseQRPayload(raw);
       expect(result.ok).toBe(false);
       if (!result.ok) {
         expect(result.error).toContain('secreto HTLC');
+      }
+    });
+
+    it('rejects malformed secret (non-hex or wrong length)', () => {
+      const raw = `micopay://release?trade_id=${TRADE_ID}&secret=ZZZ`;
+      const result = parseQRPayload(raw);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain('64 caracteres');
       }
     });
   });
@@ -39,15 +71,15 @@ describe('parseQRPayload', () => {
   // ── Claim format ───────────────────────────────────────────────────────
   describe('micopay://claim', () => {
     it('parses a valid claim QR', () => {
-      const raw = 'micopay://claim?request_id=req-456&amount_mxn=500&htlc=0xhash';
+      const raw = `micopay://claim?request_id=mcr-req456&amount_mxn=500&htlc=${HTLC_TX_HASH}`;
       const result = parseQRPayload(raw);
       expect(result.ok).toBe(true);
       if (result.ok) {
         expect(result.payload.type).toBe('claim');
         if (result.payload.type === 'claim') {
-          expect(result.payload.requestId).toBe('req-456');
+          expect(result.payload.requestId).toBe('mcr-req456');
           expect(result.payload.amountMxn).toBe(500);
-          expect(result.payload.htlc).toBe('0xhash');
+          expect(result.payload.htlc).toBe(HTLC_TX_HASH);
         }
       }
     });
@@ -60,13 +92,43 @@ describe('parseQRPayload', () => {
         expect(result.error).toContain('ID de solicitud');
       }
     });
+
+    it('rejects malformed htlc reference', () => {
+      const raw = 'micopay://claim?request_id=mcr-req456&amount_mxn=500&htlc=0xhash';
+      const result = parseQRPayload(raw);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain('HTLC');
+      }
+    });
+
+    it('rejects invalid amount_mxn', () => {
+      const raw = `micopay://claim?request_id=mcr-req456&amount_mxn=not-a-number&htlc=${HTLC_TX_HASH}`;
+      const result = parseQRPayload(raw);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain('monto MXN');
+      }
+    });
   });
 
   // ── MICOPAY: legacy format ─────────────────────────────────────────────
   describe('MICOPAY: legacy format', () => {
-    it('parses MICOPAY:DEMO:value', () => {
+    it('rejects legacy format outside demo mode', () => {
       const raw = 'MICOPAY:DEMO:mock_secret_for_ui_preview';
       const result = parseQRPayload(raw);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain('legacy MICOPAY');
+      }
+    });
+
+    it('parses MICOPAY:DEMO:value in demo mode', async () => {
+      vi.stubEnv('VITE_DEMO_MODE', 'true');
+      vi.resetModules();
+      const { parseQRPayload: parseDemo } = await import('./qrPayload');
+      const raw = 'MICOPAY:DEMO:mock_secret_for_ui_preview';
+      const result = parseDemo(raw);
       expect(result.ok).toBe(true);
       if (result.ok) {
         expect(result.payload.type).toBe('demo');
@@ -75,15 +137,22 @@ describe('parseQRPayload', () => {
           expect(result.payload.value).toBe('mock_secret_for_ui_preview');
         }
       }
+      vi.unstubAllEnvs();
+      vi.resetModules();
     });
 
-    it('returns error for incomplete MICOPAY format', () => {
+    it('returns error for incomplete MICOPAY format in demo mode', async () => {
+      vi.stubEnv('VITE_DEMO_MODE', 'true');
+      vi.resetModules();
+      const { parseQRPayload: parseDemo } = await import('./qrPayload');
       const raw = 'MICOPAY:DEMO';
-      const result = parseQRPayload(raw);
+      const result = parseDemo(raw);
       expect(result.ok).toBe(false);
       if (!result.ok) {
         expect(result.error).toContain('incompleto');
       }
+      vi.unstubAllEnvs();
+      vi.resetModules();
     });
   });
 
@@ -125,7 +194,7 @@ describe('parseQRPayload', () => {
     });
 
     it('trims whitespace before parsing', () => {
-      const raw = '  micopay://release?trade_id=abc&secret=def  ';
+      const raw = `  micopay://release?trade_id=${TRADE_ID}&secret=${SECRET_64}  `;
       const result = parseQRPayload(raw);
       expect(result.ok).toBe(true);
     });

--- a/micopay/frontend/src/utils/qrPayload.ts
+++ b/micopay/frontend/src/utils/qrPayload.ts
@@ -2,12 +2,15 @@
  * QR payload parser for MicoPay protocol QR codes.
  *
  * Supported formats:
- *   - micopay://release?trade_id=<uuid>&secret=<hex>
+ *   - micopay://release?trade_id=<uuid>&secret=<hex64>
  *   - micopay://claim?request_id=<id>&amount_mxn=<number>&htlc=<hash>
- *   - MICOPAY:<type>:<value>  (legacy demo format)
+ *   - MICOPAY:<type>:<value>  (legacy demo format — demo builds only)
  *
  * Returns a typed result or an error describing what went wrong.
  */
+
+import { IS_DEMO_MODE } from './demoMode';
+import { isHex64, isHtlcReference, isRequestId, isUuid } from './qrValidation';
 
 export interface QRPayloadRelease {
   type: 'release';
@@ -42,6 +45,13 @@ export interface QRParseError {
 
 export type QRParseResult = QRParseSuccess | QRParseError;
 
+function parseAmountMxn(raw: string | null): number | null {
+  if (raw === null || raw.trim() === '') return 0;
+  const amount = Number(raw);
+  if (!Number.isFinite(amount) || amount < 0) return null;
+  return amount;
+}
+
 /**
  * Parse a raw QR string into a typed payload object.
  */
@@ -66,13 +76,22 @@ export function parseQRPayload(raw: string | null | undefined): QRParseResult {
         if (!tradeId) {
           return { ok: false, error: 'El QR no contiene un ID de trade válido' };
         }
+        if (!isUuid(tradeId)) {
+          return { ok: false, error: 'El ID de trade no tiene un formato UUID válido' };
+        }
         if (!secret) {
           return { ok: false, error: 'El QR no contiene el secreto HTLC' };
+        }
+        if (!isHex64(secret)) {
+          return {
+            ok: false,
+            error: 'El secreto HTLC debe ser una cadena hexadecimal de 64 caracteres',
+          };
         }
 
         return {
           ok: true,
-          payload: { type: 'release', tradeId, secret },
+          payload: { type: 'release', tradeId, secret: secret.toLowerCase() },
         };
       }
 
@@ -84,14 +103,30 @@ export function parseQRPayload(raw: string | null | undefined): QRParseResult {
         if (!requestId) {
           return { ok: false, error: 'El QR de claim no contiene un ID de solicitud' };
         }
+        if (!isRequestId(requestId)) {
+          return { ok: false, error: 'El ID de solicitud no tiene un formato válido' };
+        }
+
+        const amountMxn = parseAmountMxn(amountMxnStr);
+        if (amountMxn === null) {
+          return { ok: false, error: 'El monto MXN del QR no es válido' };
+        }
+
+        const htlcValue = htlc ?? '';
+        if (htlcValue && !isHtlcReference(htlcValue, IS_DEMO_MODE)) {
+          return {
+            ok: false,
+            error: 'La referencia HTLC debe ser un hash de 64 caracteres hexadecimales',
+          };
+        }
 
         return {
           ok: true,
           payload: {
             type: 'claim',
             requestId,
-            amountMxn: amountMxnStr ? Number(amountMxnStr) : 0,
-            htlc: htlc ?? '',
+            amountMxn,
+            htlc: htlcValue,
           },
         };
       }
@@ -102,8 +137,15 @@ export function parseQRPayload(raw: string | null | undefined): QRParseResult {
     }
   }
 
-  // ── MICOPAY:<subtype>:<value> legacy demo format ─────────────────────────
+  // ── MICOPAY:<subtype>:<value> legacy demo format (demo builds only) ───────
   if (trimmed.startsWith('MICOPAY:')) {
+    if (!IS_DEMO_MODE) {
+      return {
+        ok: false,
+        error: 'El formato legacy MICOPAY ya no es compatible. Usa un QR micopay:// válido.',
+      };
+    }
+
     const parts = trimmed.split(':');
     if (parts.length >= 3) {
       return {

--- a/micopay/frontend/src/utils/qrValidation.test.ts
+++ b/micopay/frontend/src/utils/qrValidation.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isHex64,
+  isHtlcReference,
+  isRequestId,
+  isUuid,
+} from './qrValidation';
+
+describe('qrValidation', () => {
+  it('accepts 64-char hex strings', () => {
+    expect(isHex64('a'.repeat(64))).toBe(true);
+    expect(isHex64('DEADBEEF'.repeat(8))).toBe(true);
+  });
+
+  it('rejects non-hex or wrong-length strings', () => {
+    expect(isHex64('ZZZ')).toBe(false);
+    expect(isHex64('abc')).toBe(false);
+    expect(isHex64('a'.repeat(63))).toBe(false);
+    expect(isHex64('0x' + 'a'.repeat(64))).toBe(false);
+  });
+
+  it('validates UUID trade IDs', () => {
+    expect(isUuid('550e8400-e29b-41d4-a716-446655440000')).toBe(true);
+    expect(isUuid('abc-123')).toBe(false);
+  });
+
+  it('validates request IDs', () => {
+    expect(isRequestId('mcr-4b6c0e5c')).toBe(true);
+    expect(isRequestId('')).toBe(false);
+  });
+
+  it('validates HTLC references', () => {
+    const txHash = 'b'.repeat(64);
+    expect(isHtlcReference(txHash, false)).toBe(true);
+    expect(isHtlcReference('demo_htlc_123_mcr-abc', false)).toBe(false);
+    expect(isHtlcReference('demo_htlc_123_mcr-abc', true)).toBe(true);
+  });
+});

--- a/micopay/frontend/src/utils/qrValidation.ts
+++ b/micopay/frontend/src/utils/qrValidation.ts
@@ -1,0 +1,30 @@
+/** 64-char hex string (32 bytes) — HTLC preimage or Stellar tx hash. */
+export const HEX_64_PATTERN = /^[0-9a-fA-F]{64}$/;
+
+/** RFC 4122 UUID (trade IDs from backend). */
+export const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/** Cash claim request IDs (e.g. mcr-4b6c0e5c). */
+export const REQUEST_ID_PATTERN = /^[a-zA-Z0-9_-]{4,64}$/;
+
+/** Demo-only HTLC tx placeholder when on-chain lock fails. */
+export const DEMO_HTLC_PREFIX = 'demo_htlc_';
+
+export function isHex64(value: string): boolean {
+  return HEX_64_PATTERN.test(value);
+}
+
+export function isUuid(value: string): boolean {
+  return UUID_PATTERN.test(value);
+}
+
+export function isRequestId(value: string): boolean {
+  return REQUEST_ID_PATTERN.test(value);
+}
+
+export function isHtlcReference(value: string, allowDemoPlaceholder: boolean): boolean {
+  if (isHex64(value)) return true;
+  if (allowDemoPlaceholder && value.startsWith(DEMO_HTLC_PREFIX)) return true;
+  return false;
+}


### PR DESCRIPTION
## Summary

Closes #262 (SEC-30).

The mobile app QR parser (`parseQRPayload`) previously accepted `secret` and `htlc` query params without format validation, and continued to accept the legacy plaintext `MICOPAY:` scheme in release builds. This PR hardens client-side handling of HTLC-sensitive material.

**Changes:**
- Add `qrValidation.ts` with strict validators for HTLC preimage (64-char hex), Stellar tx hash, UUID trade IDs, and claim request IDs
- Reject malformed `secret`/`htlc`/`trade_id` in `parseQRPayload` with clear Spanish error messages
- Restrict legacy `MICOPAY:<subtype>:<value>` format to `VITE_DEMO_MODE=true` builds only
- Add `getDemoQrPayload()` runtime guard in `demoMode.ts` so the demo secret cannot be used outside demo mode
- Expand unit tests (24 passing) covering negative cases: `secret=ZZZ`, invalid UUID, `htlc=0xhash`, legacy format in release
- Add security audit report at `docs/security-reports/SEC-30-qr-parser-secret.md`

**Findings (documented in report):**
| Question | Result |
|----------|--------|
| Format validation for secret/htlc? | ✅ Fixed — 64-char hex required |
| HTLC preimage leaked to logs/clipboard/history? | ❌ No console logging of secret; no clipboard copy of QR payload; React state only while QR screen is mounted |
| Legacy MICOPAY: accepted in release? | ✅ Fixed — rejected unless demo mode |
| Demo secret isolated to IS_DEMO_MODE? | ✅ Confirmed — gated in QRReveal and App.tsx |

## Test plan

- [x] `cd micopay/frontend && npm test -- qrPayload qrValidation` — 24/24 pass
- [ ] Scan/inject `micopay://release?trade_id=<uuid>&secret=ZZZ` → parser rejects with format error
- [ ] Scan valid release QR from testnet backend → parses and merchant flow extracts `tradeId` correctly
- [ ] Scan `MICOPAY:DEMO:mock_secret_for_ui_preview` in prod/testnet build → rejected
- [ ] Build with `VITE_DEMO_MODE=true` → legacy format still works for UI preview fallback
- [ ] Verify no HTLC secret appears in logcat during QR reveal / merchant scan flow