### PR TITLE
frontend: show merchant reputation on Explore/Deposit cards

### DIFF
--- a/micopay/frontend/src/pages/DepositMap.tsx
+++ b/micopay/frontend/src/pages/DepositMap.tsx
@@ -214,6 +214,15 @@ function MerchantOfferCard({ merchant, amount, loading, isBest, onSelectOffer }:
                     verified
                   </span>
                 </div>
+                <div className="mt-1 text-sm text-on-surface-variant flex items-center gap-2">
+                  <span>{merchant.completion_rate !== undefined ? `${Math.round(merchant.completion_rate * 100)}% completitud` : '— completitud'}</span>
+                  <span>·</span>
+                  <span>{merchant.trades_completed ?? 0} trades</span>
+                  {merchant.tier && <span className="ml-2 px-2 py-0.5 text-[11px] font-bold rounded-md bg-surface-container-high text-primary">{merchant.tier}</span>}
+                  <span className={`ml-2 px-2 py-0.5 text-[11px] font-bold rounded-md ${((merchant.seller_type === 'business') || merchant.is_business) ? 'bg-primary/10 text-primary' : 'bg-surface-container-high text-on-surface-variant'}`}>
+                    {((merchant.seller_type === 'business') || merchant.is_business) ? 'Negocio establecido' : 'Individuo'}
+                  </span>
+                </div>
                 <div className="flex items-center gap-1 text-on-surface-variant text-xs">
                   <span className="material-symbols-outlined text-xs">near_me</span>
                   <span>{distanceLabel} de distancia</span>
@@ -264,6 +273,15 @@ function MerchantOfferCard({ merchant, amount, loading, isBest, onSelectOffer }:
           </div>
           <div>
             <h3 className="font-bold text-lg">{merchant.username}</h3>
+            <div className="mt-1 text-sm text-on-surface-variant flex items-center gap-2">
+              <span>{merchant.completion_rate !== undefined ? `${Math.round(merchant.completion_rate * 100)}%` : '—'}</span>
+              <span>·</span>
+              <span>{merchant.trades_completed ?? 0} trades</span>
+              {merchant.tier && <span className="ml-2 px-2 py-0.5 text-[10px] rounded-md bg-surface-container-high text-primary">{merchant.tier}</span>}
+              <span className={`ml-2 px-2 py-0.5 text-[10px] rounded-md ${((merchant.seller_type === 'business') || merchant.is_business) ? 'bg-primary/10 text-primary' : 'bg-surface-container-high text-on-surface-variant'}`}>
+                {((merchant.seller_type === 'business') || merchant.is_business) ? 'Negocio' : 'Individuo'}
+              </span>
+            </div>
             <div className="flex items-center gap-1 text-on-surface-variant text-xs">
               <span className="material-symbols-outlined text-xs">near_me</span>
               <span>{distanceLabel}</span>

--- a/micopay/frontend/src/pages/ExploreMap.tsx
+++ b/micopay/frontend/src/pages/ExploreMap.tsx
@@ -28,6 +28,11 @@ interface Offer {
   commissionPct: number;
   badge?: string;
   isPrimary?: boolean;
+  completionRate?: number;
+  tradesCompleted?: number;
+  tier?: string;
+  isBusiness?: boolean;
+  online?: boolean;
 }
 
 function merchantToOffer(m: AvailableMerchant, index: number): Offer {
@@ -40,6 +45,10 @@ function merchantToOffer(m: AvailableMerchant, index: number): Offer {
     receiveMxn: m.payout_mxn,
     commissionPct: m.rate_percent,
     isPrimary: index === 0,
+    completionRate: m.completion_rate ?? 0,
+    tradesCompleted: m.trades_completed ?? 0,
+    tier: m.tier ?? undefined,
+    isBusiness: (m.seller_type === 'business') || (m.is_business === true) || false,
   };
 }
 
@@ -192,6 +201,17 @@ const ExploreMap = ({
                               <span className="material-symbols-outlined text-sm">directions_walk</span>
                               {offer.distance} · {offer.walkMinutes} min
                             </p>
+                            <div className="mt-2 flex items-center gap-2">
+                              <span className="text-[12px] text-on-surface-variant">{offer.completionRate !== undefined ? `${Math.round(offer.completionRate * 100)}% completitud` : '— completitud'}</span>
+                              <span className="text-[12px] text-on-surface-variant">·</span>
+                              <span className="text-[12px] text-on-surface-variant">{offer.tradesCompleted ?? 0} trades</span>
+                              {offer.tier && (
+                                <span className="ml-2 px-2 py-0.5 text-[11px] font-bold rounded-md bg-surface-container-high text-primary">{offer.tier}</span>
+                              )}
+                              <span className={`ml-2 px-2 py-0.5 text-[11px] font-bold rounded-md ${offer.isBusiness ? 'bg-primary/10 text-primary' : 'bg-surface-container-high text-on-surface-variant'}`}>
+                                {offer.isBusiness ? 'Negocio establecido' : 'Individuo'}
+                              </span>
+                            </div>
                           </div>
                         </div>
                       </div>
@@ -253,11 +273,20 @@ const ExploreMap = ({
                         </div>
                         <div>
                           <h3 className="font-headline font-bold text-on-surface">{offer.name}</h3>
-                          {offer.badge && (
+                            {offer.badge && (
                             <span className="text-[11px] font-bold text-primary bg-primary/10 px-2 py-0.5 rounded-md">
                               {offer.badge}
                             </span>
                           )}
+                            <div className="mt-1 text-sm text-on-surface-variant flex items-center gap-2">
+                              <span>{offer.completionRate !== undefined ? `${Math.round(offer.completionRate * 100)}%` : '—'}</span>
+                              <span>·</span>
+                              <span>{offer.tradesCompleted ?? 0} trades</span>
+                              {offer.tier && <span className="ml-2 px-2 py-0.5 text-[10px] rounded-md bg-surface-container-high text-primary">{offer.tier}</span>}
+                              <span className={`ml-2 px-2 py-0.5 text-[10px] rounded-md ${offer.isBusiness ? 'bg-primary/10 text-primary' : 'bg-surface-container-high text-on-surface-variant'}`}>
+                                {offer.isBusiness ? 'Negocio' : 'Individuo'}
+                              </span>
+                            </div>
                           {isSelected && (
                             <span className="ml-2 text-[11px] font-bold text-primary bg-white px-2 py-0.5 rounded-md">
                               Seleccionado en mapa

--- a/micopay/frontend/src/services/api.ts
+++ b/micopay/frontend/src/services/api.ts
@@ -464,6 +464,16 @@ export interface AvailableMerchant {
   distance_km: number;
   /** Payout the buyer receives for the requested amount. */
   payout_mxn: number;
+  /** Reputation: fraction 0..1 of completed trades (optional) */
+  completion_rate?: number;
+  /** Total completed trades (optional) */
+  trades_completed?: number;
+  /** Reputation tier (optional) */
+  tier?: string;
+  /** Optional seller type flag coming from API (e.g. 'business' | 'individual') */
+  seller_type?: string;
+  /** Backwards-compatible boolean marker for business sellers (optional) */
+  is_business?: boolean;
 }
 
 export interface MerchantsAvailableQuery {


### PR DESCRIPTION
This PR exposes and displays merchant reputation fields in discovery cards.

What I changed:
- `micopay/frontend/src/services/api.ts`: added optional fields to `AvailableMerchant` (`completion_rate`, `trades_completed`, `tier`, `seller_type`, `is_business`).
- `micopay/frontend/src/pages/ExploreMap.tsx`: map reputation fields into the offer model and render completion %, trades completed, tier, and a visual badge distinguishing business vs individual.
- `micopay/frontend/src/pages/DepositMap.tsx`: render the same reputation information in deposit offer cards.

Acceptance criteria coverage:
- Cards now show completion rate, trades completed, and tier from the API fields.
- Business vs Individual is visually distinguished.

Notes:
- I ran `tsc --noEmit` for the frontend; there are pre-existing type errors in other parts of the frontend (missing Capacitor and other typings). Those are unrelated to these changes and pre-date this branch. The UI changes themselves type-check locally in the component files.

Please review and merge when ready.

closes #191 