### PR TITLE
fix(frontend): wire up SEC-27 telemetry redaction + correct token source

### DIFF
--- a/micopay/frontend/src/utils/reportError.ts
+++ b/micopay/frontend/src/utils/reportError.ts
@@ -52,13 +52,25 @@ export async function reportClientError(payload: {
   stack?: string;
   context?: Record<string, unknown>;
 }) {
-  // Fire and forget — don't let a reporting failure break the UX
-  readJSON<string>('token').then((token) => {
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    if (token) headers['Authorization'] = `Bearer ${token}`;
-    return axios.post(`${BASE_URL}/client-errors`, {
-      ...payload,
-      app_version: import.meta.env.VITE_APP_VERSION ?? 'dev',
-    }, { headers });
-  }).catch(() => {});
+  // SEC-27: redact secrets (JWTs, Stellar seeds, auth headers, sensitive keys)
+  // before the report ever leaves the device.
+  const safePayload = {
+    request_id: payload.request_id,
+    error_code: payload.error_code,
+    message: redactString(payload.message) ?? payload.message,
+    stack: redactString(payload.stack),
+    context: payload.context ? redactSensitiveData(payload.context) : undefined,
+    app_version: import.meta.env.VITE_APP_VERSION ?? 'dev',
+  };
+
+  // Fire and forget — don't let a reporting failure break the UX.
+  // The auth token lives nested under `micopay_users` (buyer/seller), not a flat `token` key.
+  readJSON<{ buyer?: { token?: string }; seller?: { token?: string } }>('micopay_users')
+    .then((stored) => {
+      const token = stored?.buyer?.token ?? stored?.seller?.token;
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (token) headers['Authorization'] = `Bearer ${token}`;
+      return axios.post(`${BASE_URL}/client-errors`, safePayload, { headers });
+    })
+    .catch(() => {});
 }


### PR DESCRIPTION
## Follow-up fix to #275 (SEC-27)

#275 landed the SEC-27 report and *defined* the redaction helpers, but the fix was **non-functional** in `main`:

1. **Redaction never applied** — `redactSensitiveData` / `redactString` were defined but `reportClientError` posted the raw `payload`. Stack traces and `context` (which can hold JWTs, Stellar seeds, etc.) were still sent **unredacted**.
2. **Wrong token source** — it read `readJSON('token')`, a flat key that doesn't exist. The app stores the token nested under `micopay_users` as `buyer.token`/`seller.token` (see `Login.tsx`, `TradeDetail.tsx`). Result: reports went **unauthenticated** — exactly the bug the SEC-27 report said to fix.

### Changes (single file: `micopay/frontend/src/utils/reportError.ts`)
- Build a `safePayload`: `redactString(message/stack)` + `redactSensitiveData(context)` before the POST.
- Read the auth token from `micopay_users` (`buyer.token ?? seller.token`).

### Verification
- `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)